### PR TITLE
Make Request Instance available in JavaScript

### DIFF
--- a/src/Controllers/Request.vala
+++ b/src/Controllers/Request.vala
@@ -141,6 +141,7 @@ namespace Spectator.Controllers {
                 action.finished_request.connect (() => {
                     if (item == sidebar.get_active_item ()) {
                         content.update_response (item);
+                        content.update_status (item);
                     }
                 });
 

--- a/src/Duktape/duktape.vapi
+++ b/src/Duktape/duktape.vapi
@@ -165,6 +165,9 @@ namespace Duktape {
         [CCode (cname = "duk_is_undefined")]
         public bool is_undefined(int idx);
 
+        [CCode (cname = "duk_json_encode")]
+        public unowned string json_encode(int idx);
+
         [CCode (cname = "duk_push_pointer",  simple_generics = true)]
         public void push_ref<T> (T reference);
     }

--- a/src/Models/Request.vala
+++ b/src/Models/Request.vala
@@ -56,7 +56,6 @@ namespace Spectator.Models {
         public Request (string nam, Method meth) {
             setup (nam, meth);
             id = max_id++;
-
         }
 
         public Request.with_id (string nam, Method meth, uint64 i) {
@@ -65,6 +64,16 @@ namespace Spectator.Models {
                 max_id = i;
             }
             id = max_id++;
+        }
+
+        public Request.duplicate (Request old_req) {
+            setup (old_req.name, old_req.method);
+            uri = old_req.uri;
+            request_body = old_req.request_body;
+            script = old_req.script;
+            foreach (var header in old_req.headers) {
+                add_header (header);
+            }
         }
 
         public Request.with_uri (string nam, string url, Method meth) {
@@ -83,9 +92,9 @@ namespace Spectator.Models {
             request_body = new RequestBody ();
         }
 
-        public void execute_script () {
+        public void execute_pre_script () {
             if (script.valid) {
-                script.execute (this);
+                script.execute_before_sending (this);
             }
         }
 

--- a/src/Models/Script.vala
+++ b/src/Models/Script.vala
@@ -27,7 +27,6 @@ public Duktape.ReturnType add_request_header (Duktape.Context ctx) {
     if (request == null) return 0;
 
     if (ctx.is_string (-1) && ctx.is_string (-2)) {
-        stdout.printf ("asdasd\n");
         request.add_header (new Spectator.Pair(ctx.get_string (-2), ctx.get_string (-1)));
     }
     return 0;
@@ -194,7 +193,7 @@ namespace Spectator.Models {
             }
         }
 
-        public void execute (Models.Request request) {
+        public void execute_before_sending (Models.Request request) {
             evaluate_code ();
             context.get_global_string ("before_sending");
             if (context.is_function(-1)) {

--- a/src/Models/Script.vala
+++ b/src/Models/Script.vala
@@ -195,30 +195,31 @@ namespace Spectator.Models {
 
         public void execute_before_sending (Models.Request request) {
             evaluate_code ();
-            context.get_global_string ("before_sending");
-            if (context.is_function(-1)) {
-                context.push_ref (request);
-                context.put_global_string (Duktape.hidden_symbol("request"));
+            if (valid) {
+                context.get_global_string ("before_sending");
+                if (context.is_function(-1)) {
+                    context.push_ref (request);
+                    context.put_global_string (Duktape.hidden_symbol("request"));
 
-                var obj_idx = context.push_object ();
-                context.push_string (request.name);
-                context.put_prop_string (obj_idx, "name");
-                context.push_string (request.uri);
-                context.put_prop_string (obj_idx, "uri");
-                context.push_string (request.method.to_str ());
-                context.put_prop_string (obj_idx, "method");
+                    var obj_idx = context.push_object ();
+                    context.push_string (request.name);
+                    context.put_prop_string (obj_idx, "name");
+                    context.push_string (request.uri);
+                    context.put_prop_string (obj_idx, "uri");
+                    context.push_string (request.method.to_str ());
+                    context.put_prop_string (obj_idx, "method");
 
-                var header_obj = context.push_object ();
-                foreach (var header in request.headers) {
-                    // TODO: If header already exists, append it
-                    context.push_string (header.val);
-                    context.put_prop_string (header_obj, header.key);
+                    var header_obj = context.push_object ();
+                    foreach (var header in request.headers) {
+                        context.push_string (header.val);
+                        context.put_prop_string (header_obj, header.key);
+                    }
+                    context.put_prop_string (obj_idx, "headers");
+                    context.push_vala_function (add_request_header, 2);
+                    context.put_prop_string (obj_idx, "add_header");
+                    context.call (1);
+                    context.pop ();
                 }
-                context.put_prop_string (obj_idx, "headers");
-                context.push_vala_function (add_request_header, 2);
-                context.put_prop_string (obj_idx, "add_header");
-                context.call (1);
-                context.pop ();
             }
         }
     }

--- a/src/Services/RequestAction.vala
+++ b/src/Services/RequestAction.vala
@@ -149,11 +149,14 @@ namespace Spectator {
 
             loop = new MainLoop ();
 
+            var tmp_req = new Models.Request.duplicate (item);
+            tmp_req.execute_pre_script ();
+
             session.timeout = (uint) settings.timeout;
 
-            var method = item.method;
+            var method = tmp_req.method;
 
-            var msg = new Soup.Message (method.to_str (), item.uri);
+            var msg = new Soup.Message (method.to_str (), tmp_req.uri);
 
             if (settings.use_proxy) {
                 var proxy_resolver = new SimpleProxyResolver (null, null);
@@ -176,7 +179,8 @@ namespace Spectator {
 
             var user_agent = "";
             var content_type_set = false;
-            foreach (var header in item.headers) {
+
+            foreach (var header in tmp_req.headers) {
                 if (header.key == "User-Agent") {
                     user_agent = header.val;
                     continue;
@@ -188,12 +192,12 @@ namespace Spectator {
                     continue;
                 }
 
-                if (header.key == "")
+                if (header.key == "") continue;
                 msg.request_headers.append (header.key, header.val);
             }
 
             if (method == Models.Method.POST || method == Models.Method.PUT || method == Models.Method.PATCH) {
-                var body = item.request_body;
+                var body = tmp_req.request_body;
                 if (is_raw_type (body.type)) {
                     if (content_type_set) {
                         msg.set_request (null, Soup.MemoryUse.COPY, body.raw.data);
@@ -233,8 +237,6 @@ namespace Spectator {
             } else {
                 session.user_agent = user_agent;
             }
-
-            item.execute_script ();
 
             session.queue_message (msg, read_response);
         }


### PR DESCRIPTION
This change improves the simple JavaScript capabilities of Spectator.

The user has now access to the request object, which is defined in the Spectator application.
Furthermore the user can add addiotional, temporary headers in the script.

The post function in JavaScript was also improved and can now create JSON/UrlEncoded/FormData bodies.