### PR TITLE
Add Environments and Variables to Spectator

### DIFF
--- a/data/com.github.treagod.spectator.gschema.xml
+++ b/data/com.github.treagod.spectator.gschema.xml
@@ -125,6 +125,12 @@
             <summary>Editor Scheme.</summary>
             <description>Specifies which color scheme shall be used for the editor.</description>
         </key>
+
+        <key name="current-environment" type="s">
+            <default>''</default>
+            <summary>Current Environment.</summary>
+            <description>Specifies the name of the current environment.</description>
+        </key>
     </schema>
 </schemalist>
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -117,14 +117,6 @@ namespace Spectator {
         protected override void activate () {
             this.load_database ();
             if (!running) {
-                
-                
-                //  while (info.matches ()) {
-                //      print ("%s\n", info.fetch (0));
-                //      print ("%s\n", info.fetch (1));
-                //      info.next ();
-                //  }
-
                 var rs = new Repository.SQLiteRequest (db);
                 var cs = new Repository.SQLiteCollection (db);
                 var os = new Repository.SQLiteCustomOrder (db);

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -84,6 +84,32 @@ namespace Spectator {
                 stderr.printf ("Error: %s\n", errmsg);
                 Process.exit(1);
             }
+
+            var db_version = get_db_version ();
+
+            if (db_version >= 60) {
+                ec = db.exec (Queries.Migrate060.CREATE_ENVIRONMENT_TABLE, null, out errmsg);
+                if (ec != Sqlite.OK) {
+                    stderr.printf ("Error: %s\n", errmsg);
+                    Process.exit(1);
+                }
+                ec = db.exec (Queries.Migrate060.CREATE_VARIABLE_TABLE, null, out errmsg);
+                if (ec != Sqlite.OK) {
+                    stderr.printf ("Error: %s\n", errmsg);
+                    Process.exit(1);
+                }
+            } else if (db_version < 60) {
+                ec = db.exec (Queries.Migrate060.DROP_ENVIRONMENT_TABLE, null, out errmsg);
+                if (ec != Sqlite.OK) {
+                    stderr.printf ("Error: %s\n", errmsg);
+                    Process.exit(1);
+                }
+                ec = db.exec (Queries.Migrate060.DROP_VARIABLE_TABLE, null, out errmsg);
+                if (ec != Sqlite.OK) {
+                    stderr.printf ("Error: %s\n", errmsg);
+                    Process.exit(1);
+                }
+            }
         }
 
         private void load_legacy (Repository.ICollection collections, Repository.IRequest requests) {
@@ -114,16 +140,35 @@ namespace Spectator {
             }
         }
 
+        private int get_db_version () {
+            var version_parts = Constants.VERSION.split(".");
+            var sum = 0;
+            // Coefficient, major version 'x * 100', minor version 'x * 10', bugfix version 'x * 1'
+            var cof = 100;
+
+            for (uint i = 0; i < version_parts.length; i++) {
+                sum += int.parse (version_parts[i]) * cof;
+                cof /= 10;
+            }
+
+            return sum;
+        }
+
         protected override void activate () {
             this.load_database ();
+            
             if (!running) {
                 var rs = new Repository.SQLiteRequest (db);
                 var cs = new Repository.SQLiteCollection (db);
                 var os = new Repository.SQLiteCustomOrder (db);
-                var es = new Repository.InMemoryEnvironment ();
+                //var es = new Repository.InMemoryEnvironment ();
+                var ses = new Repository.SQLiteEnvironment (db);
+                
+                
                 this.load_legacy (cs, rs);
+                var window_builder = new Services.WindowBuilder (rs, cs, os, ses);
 
-                var window = new Spectator.Window(this, rs, cs, os, es);
+                var window = window_builder.build_window (this);
                 this.add_window (window);
 
                 window.show_content ();

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -120,9 +120,10 @@ namespace Spectator {
                 var rs = new Repository.SQLiteRequest (db);
                 var cs = new Repository.SQLiteCollection (db);
                 var os = new Repository.SQLiteCustomOrder (db);
+                var es = new Repository.InMemoryEnvironment ();
                 this.load_legacy (cs, rs);
 
-                var window = new Spectator.Window(this, rs, cs, os);
+                var window = new Spectator.Window(this, rs, cs, os, es);
                 this.add_window (window);
 
                 window.show_content ();

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -117,6 +117,14 @@ namespace Spectator {
         protected override void activate () {
             this.load_database ();
             if (!running) {
+                
+                
+                //  while (info.matches ()) {
+                //      print ("%s\n", info.fetch (0));
+                //      print ("%s\n", info.fetch (1));
+                //      info.next ();
+                //  }
+
                 var rs = new Repository.SQLiteRequest (db);
                 var cs = new Repository.SQLiteCollection (db);
                 var os = new Repository.SQLiteCustomOrder (db);

--- a/src/Dialogs/Environment/EnvironmentVariables.vala
+++ b/src/Dialogs/Environment/EnvironmentVariables.vala
@@ -26,6 +26,8 @@ namespace Spectator.Dialogs {
         private Gtk.Label no_such_environment;
         private Gtk.Box variable_container;
         private string current_env_name;
+        private uint key_timeout_id;
+        private uint value_timeout_id;
 
         public signal void variable_added ();
 
@@ -77,12 +79,12 @@ namespace Spectator.Dialogs {
                         var variable_name_entry = new Gtk.Entry ();
                         variable_name_entry.text = variable.key;
                         variable_name_entry.changed.connect (() => {
-                            environments.update_variable_name_in_environment (env, variable.id, variable_name_entry.text);
+                            save_key_after_timeout (env, variable.id, variable_name_entry.text);
                         });
                         var variable_value_entry = new Gtk.Entry();
                         variable_value_entry.text = variable.val;
                         variable_value_entry.changed.connect (() => {
-                            environments.update_variable_value_in_environment (env, variable.id, variable_value_entry.text);
+                            save_value_after_timeout (env, variable.id, variable_value_entry.text);
                         });
                         var del_button = new Gtk.Button.from_icon_name ("window-close");
                         del_button.clicked.connect (() => {
@@ -102,5 +104,32 @@ namespace Spectator.Dialogs {
 
             show_all ();
         }
+
+        private void save_key_after_timeout (Models.Environment env, string id, string key) {
+            if (key_timeout_id > 0) {
+                Source.remove (key_timeout_id);
+                key_timeout_id = 0;
+            }
+
+            key_timeout_id = Timeout.add (275, () => {
+                environments.update_variable_name_in_environment (env, id, key);
+                key_timeout_id = 0;
+                return false;
+            });
+        }
+
+        private void save_value_after_timeout (Models.Environment env, string id, string val) {
+            if (value_timeout_id > 0) {
+                Source.remove (value_timeout_id);
+                value_timeout_id = 0;
+            }
+
+            value_timeout_id = Timeout.add (275, () => {
+                environments.update_variable_value_in_environment (env, id, val);
+                value_timeout_id = 0;
+                return false;
+            });
+        }
     }
 }
+

--- a/src/Dialogs/Environment/EnvironmentVariables.vala
+++ b/src/Dialogs/Environment/EnvironmentVariables.vala
@@ -24,48 +24,80 @@ namespace Spectator.Dialogs {
         private weak Repository.IEnvironment environments;
         private Gtk.Label no_variables_defined;
         private Gtk.Label no_such_environment;
+        private Gtk.Box variable_container;
+        private string current_env_name;
+
+        public signal void variable_added ();
 
         construct {
             orientation = Gtk.Orientation.VERTICAL;
-            margin = 1;
             halign = Gtk.Align.CENTER;
+            hexpand = true;
         }
 
         public EnvironmentVariables(Repository.IEnvironment env) {
             environments = env;
+            variable_container = new Gtk.Box (Gtk.Orientation.VERTICAL, 2);
             no_variables_defined = new Gtk.Label (_("No variables defined yet"));
             no_such_environment = new Gtk.Label (_("No such environment"));
+            variable_container = new Gtk.Box (Gtk.Orientation.VERTICAL, 5);
+            
+            var add_row_button = new Gtk.Button.with_label (_("Add variable"));
+
+            add_row_button.get_style_context ().add_class ("add-row-btn");
+
+            add_row_button.clicked.connect (() => {
+                environments.add_variable_to_environment (current_env_name);
+                show_environment_variables (current_env_name.strip ()); // Refactor.. something fishy here
+            });
+
+            add (variable_container);
+            add (add_row_button);
         }
 
         private void clear () {
-            this.foreach ((w) => {
-                remove (w);
+            variable_container.foreach ((w) => {
+                variable_container.remove (w);
             });
         }
 
         public void show_environment_variables (string env_name) {
             clear ();
+            current_env_name = env_name;
             
             var env = environments.get_environment_by_name (env_name);
+            var env_variables = environments.get_environment_variables (env_name);
 
             if (env != null) {
-                if (env.get_variable_names ().is_empty) {
-                    // Todo: Make singleton
-                    add (no_variables_defined);
+                if (env_variables.is_empty) {
+                    variable_container.add (no_variables_defined);
                 } else {
-                    foreach (var variable in env.get_variable_names ()) {
+                    foreach (var variable in env_variables) {
                         var box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 3);
                         var variable_name_entry = new Gtk.Entry ();
-                        variable_name_entry.text = variable;
+                        variable_name_entry.text = variable.key;
+                        variable_name_entry.changed.connect (() => {
+                            environments.update_variable_name_in_environment (env, variable.id, variable_name_entry.text);
+                        });
                         var variable_value_entry = new Gtk.Entry();
-                        variable_value_entry.text =  env.get_variable (variable);
-                        box.add (variable_name_entry);
-                        box.add (variable_value_entry);
-                        add (box);
+                        variable_value_entry.text = variable.val;
+                        variable_value_entry.changed.connect (() => {
+                            environments.update_variable_value_in_environment (env, variable.id, variable_value_entry.text);
+                        });
+                        var del_button = new Gtk.Button.from_icon_name ("window-close");
+                        del_button.clicked.connect (() => {
+                            environments.delete_variable_value_in_environment (env, variable.id);
+                            show_environment_variables (env_name);
+                        });
+                        box.pack_start (variable_name_entry);
+                        box.pack_start (variable_value_entry);
+                        box.add (del_button);
+                        box.hexpand = true;
+                        variable_container.add (box);
                     }
                 }
             } else {
-                add (no_such_environment);
+                variable_container.add (no_such_environment);
             }
 
             show_all ();

--- a/src/Dialogs/Environment/EnvironmentVariables.vala
+++ b/src/Dialogs/Environment/EnvironmentVariables.vala
@@ -1,0 +1,74 @@
+/*
+* Copyright (c) 2021 Marvin Ahlgrimm (https://github.com/treagod)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 2 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*
+* Authored by: Marvin Ahlgrimm <marv.ahlgrimm@gmail.com>
+*/
+
+namespace Spectator.Dialogs {
+    public class EnvironmentVariables : Gtk.Box {
+        private weak Repository.IEnvironment environments;
+        private Gtk.Label no_variables_defined;
+        private Gtk.Label no_such_environment;
+
+        construct {
+            orientation = Gtk.Orientation.VERTICAL;
+            margin = 1;
+            halign = Gtk.Align.CENTER;
+        }
+
+        public EnvironmentVariables(Repository.IEnvironment env) {
+            environments = env;
+            no_variables_defined = new Gtk.Label (_("No variables defined yet"));
+            no_such_environment = new Gtk.Label (_("No such environment"));
+        }
+
+        private void clear () {
+            this.foreach ((w) => {
+                remove (w);
+            });
+        }
+
+        public void show_environment_variables (string env_name) {
+            clear ();
+            
+            var env = environments.get_environment_by_name (env_name);
+
+            if (env != null) {
+                if (env.get_variable_names ().is_empty) {
+                    // Todo: Make singleton
+                    add (no_variables_defined);
+                } else {
+                    foreach (var variable in env.get_variable_names ()) {
+                        var box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 3);
+                        var variable_name_entry = new Gtk.Entry ();
+                        variable_name_entry.text = variable;
+                        var variable_value_entry = new Gtk.Entry();
+                        variable_value_entry.text =  env.get_variable (variable);
+                        box.add (variable_name_entry);
+                        box.add (variable_value_entry);
+                        add (box);
+                    }
+                }
+            } else {
+                add (no_such_environment);
+            }
+
+            show_all ();
+        }
+    }
+}

--- a/src/Dialogs/Environment/NewEnvironment.vala
+++ b/src/Dialogs/Environment/NewEnvironment.vala
@@ -23,6 +23,7 @@ namespace Spectator.Dialogs {
     public class NewEnvironment : Gtk.Dialog {
         private Gtk.Entry entry;
         private Gtk.Label warning;
+        private Gtk.Box message_box;
         private weak Repository.IEnvironment environment;
 
         public signal void environemnt_created ();
@@ -61,14 +62,17 @@ namespace Spectator.Dialogs {
                 }
             });
 
+            message_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
             var content = get_content_area () as Gtk.Box;
             content.pack_start (box);
+            content.pack_start (message_box);
 
             content.margin = 15;
             content.margin_top = 0;
         }
 
         private void create_environment () {
+            entry.get_style_context ().remove_class ("error");
             if (entry.text.length == 0) {
                 show_error (_("Environment name must not be empty"));
                 return;
@@ -84,13 +88,14 @@ namespace Spectator.Dialogs {
         }
 
         private void show_error (string warning_string) {
-            var content = get_content_area () as Gtk.Box;
-            content.remove (warning);
+            message_box.foreach ((w) => {
+                message_box.remove (w);
+            });
 
             warning = new Gtk.Label ("<span color=\"#a10705\">" + warning_string + "</span>");
             warning.use_markup = true;
             warning.margin = 5;
-            content.pack_start (warning, false, true, 0);
+            message_box.pack_start (warning, false, true, 0);
             show_all ();
             entry.get_style_context ().add_class ("error");
         }

--- a/src/Dialogs/Environment/NewEnvironment.vala
+++ b/src/Dialogs/Environment/NewEnvironment.vala
@@ -1,0 +1,98 @@
+/*
+* Copyright (c) 2021 Marvin Ahlgrimm (https://github.com/treagod)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 2 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*
+* Authored by: Marvin Ahlgrimm <marv.ahlgrimm@gmail.com>
+*/
+
+namespace Spectator.Dialogs {
+    public class NewEnvironment : Gtk.Dialog {
+        private Gtk.Entry entry;
+        private Gtk.Label warning;
+        private weak Repository.IEnvironment environment;
+
+        public signal void environemnt_created ();
+
+        public NewEnvironment (Window parent) {
+            title = _("New Environment");
+            border_width = 5;
+            deletable = false;
+            resizable = false;
+            transient_for = parent;
+            modal = true;
+            environment = parent.environment_service;
+
+            var box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 5);
+            var label = new Gtk.Label (_("Environment Name"));
+            entry = new Gtk.Entry ();
+
+            box.pack_start (label);
+            box.pack_start (entry);
+
+            add_button (_("Create"), Gtk.ResponseType.APPLY);
+            add_button (_("Close"), Gtk.ResponseType.CLOSE);
+
+            entry.activate.connect (() => {
+                create_environment ();
+            });
+
+            response.connect ((source, id) => {
+                switch (id) {
+                case Gtk.ResponseType.APPLY:
+                    create_environment ();
+                    break;
+                case Gtk.ResponseType.CLOSE:
+                    destroy ();
+                    break;
+                }
+            });
+
+            var content = get_content_area () as Gtk.Box;
+            content.pack_start (box);
+
+            content.margin = 15;
+            content.margin_top = 0;
+        }
+
+        private void create_environment () {
+            if (entry.text.length == 0) {
+                show_error (_("Environment name must not be empty"));
+                return;
+            }
+
+            try {
+                environment.create_environment (entry.text);
+                environemnt_created ();
+                destroy ();
+            } catch (Repository.RecordExistsError e) {
+                show_error (_("Environment name already exists"));
+            }
+        }
+
+        private void show_error (string warning_string) {
+            var content = get_content_area () as Gtk.Box;
+            content.remove (warning);
+
+            warning = new Gtk.Label ("<span color=\"#a10705\">" + warning_string + "</span>");
+            warning.use_markup = true;
+            warning.margin = 5;
+            content.pack_start (warning, false, true, 0);
+            show_all ();
+            entry.get_style_context ().add_class ("error");
+        }
+    }
+}

--- a/src/Dialogs/Environments.vala
+++ b/src/Dialogs/Environments.vala
@@ -56,7 +56,7 @@ namespace Spectator.Dialogs {
         }
 
         private void build_headerbar (Repository.IEnvironment repository) {
-            var headerbar = get_header_bar ();
+            var headerbar = (Gtk.HeaderBar) get_header_bar (); // Todo: Remove type-cast with modern compiler (Odin)
             var new_environment = new Gtk.Button.from_icon_name ("bookmark-new", Gtk.IconSize.LARGE_TOOLBAR);
             new_environment.tooltip_text = _("Create Environment");
             new_environment.clicked.connect (() => {
@@ -67,7 +67,8 @@ namespace Spectator.Dialogs {
                     });
 
                     foreach (var env in repository.get_environments ()) {
-                        environment_list.add (new EnvironmentRow (env.name));
+                        var new_row = new EnvironmentRow (env.name);
+                        environment_list.add (new_row);
                     }
                     environment_list.show_all ();
                 });

--- a/src/Dialogs/Environments.vala
+++ b/src/Dialogs/Environments.vala
@@ -1,0 +1,44 @@
+/*
+* Copyright (c) 2021 Marvin Ahlgrimm (https://github.com/treagod)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 2 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*
+* Authored by: Marvin Ahlgrimm <marv.ahlgrimm@gmail.com>
+*/
+
+namespace Spectator.Dialogs {
+    public class Environments : Gtk.Dialog {
+        public Environments (Gtk.Window parent) {
+            title = _("Environments");
+            border_width = 5;
+            deletable = false;
+            resizable = false;
+            transient_for = parent;
+            modal = true;
+
+            add_button (_("Close"), Gtk.ResponseType.CLOSE);
+
+            response.connect ((source, id) => {
+                destroy ();
+            });
+
+            var content = get_content_area () as Gtk.Box;
+
+            content.margin = 15;
+            content.margin_top = 0;
+        }
+    }
+}

--- a/src/Dialogs/Environments.vala
+++ b/src/Dialogs/Environments.vala
@@ -110,7 +110,7 @@ namespace Spectator.Dialogs {
                 }
             });
 
-            content.width_request = 675;
+            content.width_request = 670;
             content.height_request = 460;
 
             content.add (paned);

--- a/src/Dialogs/meson.build
+++ b/src/Dialogs/meson.build
@@ -7,6 +7,8 @@ sources += files(
 	'Collection/UpdateCollection.vala',
 	'Alert.vala',
 	'Environments.vala',
+	'Environment/NewEnvironment.vala',
+	'Environment/EnvironmentVariables.vala',
 	'Preferences.vala',
 	'Preference/General.vala',
 	'Preference/Network.vala',

--- a/src/Dialogs/meson.build
+++ b/src/Dialogs/meson.build
@@ -6,6 +6,7 @@ sources += files(
 	'Collection/CreateCollection.vala',
 	'Collection/UpdateCollection.vala',
 	'Alert.vala',
+	'Environments.vala',
 	'Preferences.vala',
 	'Preference/General.vala',
 	'Preference/Network.vala',

--- a/src/Models/Environment.vala
+++ b/src/Models/Environment.vala
@@ -28,5 +28,17 @@ namespace Spectator.Models {
             name = n;
             variables = new Gee.HashMap<string, string> ();
         }
+
+        public Gee.Set<string> get_variable_names () {
+            return variables.keys;
+        }
+
+        public string? get_variable (string variable_name)  {
+            if (variables.has_key (variable_name)) {
+                return variables.get (variable_name);
+            }
+
+            return null;
+        }
     }
 }

--- a/src/Models/Environment.vala
+++ b/src/Models/Environment.vala
@@ -21,21 +21,18 @@
 
 namespace Spectator.Models {
     public class Environment {
-        public string name { get; private set; }
+        public string name;
         public Gee.HashMap<string, Models.Variable> variables { get; private set; }
+        public DateTime created_at;
 
         public Environment (string n) {
             name = n;
             variables = new Gee.HashMap<string, Models.Variable> ();
+            created_at = new DateTime.now_utc ();
         }
 
-        public Models.Variable? get_variable (string id)  {
-            foreach (var v in variables.values) {
-                if (v.key == id) {
-                    return v;
-                }
-            }
-            return null;
+        public Environment.empty () {
+            variables = new Gee.HashMap<string, Models.Variable> ();
         }
     }
 }

--- a/src/Models/Environment.vala
+++ b/src/Models/Environment.vala
@@ -19,29 +19,14 @@
 * Authored by: Marvin Ahlgrimm <marv.ahlgrimm@gmail.com>
 */
 
-namespace Spectator.Dialogs {
-    public class Environments : Gtk.Dialog {
-        public Environments (Gtk.Window parent) {
-            title = _("Environments");
-            border_width = 5;
-            deletable = false;
-            resizable = false;
-            transient_for = parent;
-            modal = true;
+namespace Spectator.Models {
+    public class Environment {
+        public string name { get; private set; }
+        public Gee.HashMap<string, string> variables { get; private set; }
 
-            add_button (_("Close"), Gtk.ResponseType.CLOSE);
-
-            response.connect ((source, id) => {
-                destroy ();
-            });
-
-            var content = get_content_area () as Gtk.Box;
-
-            content.width_request = 675;
-            content.height_request = 460;
-
-            content.margin = 15;
-            content.margin_top = 0;
+        public Environment (string n) {
+            name = n;
+            variables = new Gee.HashMap<string, string> ();
         }
     }
 }

--- a/src/Models/Variable.vala
+++ b/src/Models/Variable.vala
@@ -20,22 +20,18 @@
 */
 
 namespace Spectator.Models {
-    public class Environment {
-        public string name { get; private set; }
-        public Gee.HashMap<string, Models.Variable> variables { get; private set; }
+    //[Compact] Maybe in a moderner compiler?
+    public class Variable {
+        public string id;
+        public string key;
+        public string val;
+        public DateTime created_at { get; private set; }
 
-        public Environment (string n) {
-            name = n;
-            variables = new Gee.HashMap<string, Models.Variable> ();
-        }
-
-        public Models.Variable? get_variable (string id)  {
-            foreach (var v in variables.values) {
-                if (v.key == id) {
-                    return v;
-                }
-            }
-            return null;
+        public Variable (string k, string v) {
+            id = Uuid.string_random ();
+            created_at = new DateTime.now_utc ();
+            key = k;
+            val = v;
         }
     }
 }

--- a/src/Models/Variable.vala
+++ b/src/Models/Variable.vala
@@ -25,7 +25,7 @@ namespace Spectator.Models {
         public string id;
         public string key;
         public string val;
-        public DateTime created_at { get; private set; }
+        public DateTime created_at;
 
         public Variable (string k, string v) {
             id = Uuid.string_random ();
@@ -33,5 +33,7 @@ namespace Spectator.Models {
             key = k;
             val = v;
         }
+
+        public Variable.empty () {}
     }
 }

--- a/src/Models/meson.build
+++ b/src/Models/meson.build
@@ -3,6 +3,7 @@ sources += files(
 	'Collection.vala',
 	'Request.vala',
     'Method.vala',
+    'Environment.vala',
     'RequestBody.vala',
 	'ResponseItem.vala',
     'Script.vala',

--- a/src/Models/meson.build
+++ b/src/Models/meson.build
@@ -3,6 +3,7 @@ sources += files(
 	'Collection.vala',
 	'Request.vala',
     'Method.vala',
+    'Variable.vala',
     'Environment.vala',
     'RequestBody.vala',
 	'ResponseItem.vala',

--- a/src/Repository/IEnvironment.vala
+++ b/src/Repository/IEnvironment.vala
@@ -23,5 +23,7 @@
 namespace Spectator.Repository {
     public interface IEnvironment : Object {
         public abstract Gee.ArrayList<Models.Environment> get_environments ();
+        public abstract Models.Environment get_current_environment ();
+        public abstract void set_current_environment (Models.Environment env);
     }
 }

--- a/src/Repository/IEnvironment.vala
+++ b/src/Repository/IEnvironment.vala
@@ -30,6 +30,11 @@ namespace Spectator.Repository {
         public abstract Models.Environment? get_environment_by_name (string name);
         public abstract Models.Environment get_current_environment ();
         public abstract void set_current_environment (Models.Environment env);
+        public abstract void add_variable_to_environment (string env_name);
+        public abstract void delete_variable_value_in_environment (Models.Environment env, string variable_id);
         public abstract void create_environment (string name) throws RecordExistsError;
+        public abstract Gee.ArrayList<Models.Variable> get_environment_variables(string env_name);
+        public abstract void update_variable_name_in_environment (Models.Environment env, string id, string key);
+        public abstract void update_variable_value_in_environment (Models.Environment env, string id, string value1);
     }
 }

--- a/src/Repository/IEnvironment.vala
+++ b/src/Repository/IEnvironment.vala
@@ -21,9 +21,15 @@
 
 
 namespace Spectator.Repository {
+    public errordomain RecordExistsError {
+        CODE_1A
+    }
+
     public interface IEnvironment : Object {
         public abstract Gee.ArrayList<Models.Environment> get_environments ();
+        public abstract Models.Environment? get_environment_by_name (string name);
         public abstract Models.Environment get_current_environment ();
         public abstract void set_current_environment (Models.Environment env);
+        public abstract void create_environment (string name) throws RecordExistsError;
     }
 }

--- a/src/Repository/IEnvironment.vala
+++ b/src/Repository/IEnvironment.vala
@@ -36,5 +36,7 @@ namespace Spectator.Repository {
         public abstract Gee.ArrayList<Models.Variable> get_environment_variables(string env_name);
         public abstract void update_variable_name_in_environment (Models.Environment env, string id, string key);
         public abstract void update_variable_value_in_environment (Models.Environment env, string id, string value1);
+        public abstract Models.Variable? get_variables_in_environment_by_name (string env_name, string variable_name);
+        public abstract Models.Variable? get_variables_in_current_environment_by_name (string variable_name);
     }
 }

--- a/src/Repository/IEnvironment.vala
+++ b/src/Repository/IEnvironment.vala
@@ -19,29 +19,9 @@
 * Authored by: Marvin Ahlgrimm <marv.ahlgrimm@gmail.com>
 */
 
-namespace Spectator.Dialogs {
-    public class Environments : Gtk.Dialog {
-        public Environments (Gtk.Window parent) {
-            title = _("Environments");
-            border_width = 5;
-            deletable = false;
-            resizable = false;
-            transient_for = parent;
-            modal = true;
 
-            add_button (_("Close"), Gtk.ResponseType.CLOSE);
-
-            response.connect ((source, id) => {
-                destroy ();
-            });
-
-            var content = get_content_area () as Gtk.Box;
-
-            content.width_request = 675;
-            content.height_request = 460;
-
-            content.margin = 15;
-            content.margin_top = 0;
-        }
+namespace Spectator.Repository {
+    public interface IEnvironment : Object {
+        public abstract Gee.ArrayList<Models.Environment> get_environments ();
     }
 }

--- a/src/Repository/InMemoryEnvironment.vala
+++ b/src/Repository/InMemoryEnvironment.vala
@@ -19,20 +19,32 @@
 * Authored by: Marvin Ahlgrimm <marv.ahlgrimm@gmail.com>
 */
 
-
 namespace Spectator.Repository {
     public class InMemoryEnvironment : IEnvironment, Object {
         private Gee.ArrayList<Models.Environment> envs;
-        public Gee.ArrayList<Models.Environment> get_environments () {
+        
+        public InMemoryEnvironment () {
             envs = new Gee.ArrayList<Models.Environment> ();
             var env = new Models.Environment ("My Environment");
-            env.variables["id"] = "123";
+            env.variables["id"] = "5";
             env.variables["base_url"] = "http://localhost:3456";
+            env.variables["placeholder"] = "https://jsonplaceholder.typicode.com";
             envs.add (env);
             envs.add (new Models.Environment ("Development"));
             envs.add (new Models.Environment ("Woop"));
-            
+        }
+        public Gee.ArrayList<Models.Environment> get_environments () {
             return envs;
+        }
+
+        public Models.Environment? get_environment_by_name (string name) {
+            foreach (var env in envs) {
+                if (env.name == name ) {
+                    return env;
+                }
+            }
+
+            return null;
         }
 
         public Models.Environment get_current_environment () {
@@ -43,5 +55,16 @@ namespace Spectator.Repository {
             // Do something
         }
 
+        public void create_environment (string name) throws RecordExistsError {
+            var env = new Models.Environment (name);
+
+            foreach (var e in envs) {
+                if (e.name == name) {
+                    throw new RecordExistsError.CODE_1A (_("Environment name already exists"));
+                }
+            }
+
+            envs.add (env);
+        }
     }
 }

--- a/src/Repository/InMemoryEnvironment.vala
+++ b/src/Repository/InMemoryEnvironment.vala
@@ -22,19 +22,81 @@
 namespace Spectator.Repository {
     public class InMemoryEnvironment : IEnvironment, Object {
         private Gee.ArrayList<Models.Environment> envs;
+        private int current_env;
         
         public InMemoryEnvironment () {
             envs = new Gee.ArrayList<Models.Environment> ();
+            current_env = 0;
             var env = new Models.Environment ("My Environment");
-            env.variables["id"] = "5";
-            env.variables["base_url"] = "http://localhost:3456";
-            env.variables["placeholder"] = "https://jsonplaceholder.typicode.com";
+            var v = new Models.Variable  ("id", "5");
+            env.variables[v.id] = v;
+            v = new Models.Variable  ("base_url", "http://localhost:3456");
+            env.variables[v.id] = v;
+            v = new Models.Variable  ("placeholder", "https://jsonplaceholder.typicode.com");
+            env.variables[v.id] = v;
             envs.add (env);
-            envs.add (new Models.Environment ("Development"));
+            env = new Models.Environment ("Development");
+            v = new Models.Variable  ("id", "5");
+            env.variables[v.id] = v;
+            envs.add (env);
             envs.add (new Models.Environment ("Woop"));
         }
+
+        public void add_variable_to_environment (string env_name) {
+            foreach (var env in envs) {
+                if (env.name == env_name) {
+                    var variable = new Models.Variable ("", "");
+                    env.variables[variable.id] = variable;
+                    return;
+                }
+            }
+        }
+
+        public void delete_variable_value_in_environment (Models.Environment env, string variable_id) {
+            foreach (var e in envs) {
+                if (e.name == env.name) {
+                    e.variables.unset (variable_id);
+                    return;
+                }
+            }
+        }
+
         public Gee.ArrayList<Models.Environment> get_environments () {
             return envs;
+        }
+
+        public Gee.ArrayList<Models.Variable> get_environment_variables (string env_name) {
+            foreach (var env in envs) {
+                if (env.name == env_name) {
+                    var sorted_variables = new Gee.ArrayList<Models.Variable> ();
+                    sorted_variables.add_all (env.variables.values);
+
+                    sorted_variables.sort((a,b) => {
+                        return a.created_at.compare (b.created_at);
+                    });
+
+                    return sorted_variables;
+                }
+            }
+            return new Gee.ArrayList<Models.Variable> ();
+        }
+
+        public void update_variable_name_in_environment (Models.Environment env, string id, string key) {
+            foreach (var e in envs) {
+                if (e.name == env.name) {
+                    e.variables[id].key = key;
+                    return;
+                }
+            }
+        }
+
+        public void update_variable_value_in_environment (Models.Environment env, string id, string value) {
+            foreach (var e in envs) {
+                if (e.name == env.name) {
+                    e.variables[id].val = value;
+                    return;
+                }
+            }
         }
 
         public Models.Environment? get_environment_by_name (string name) {
@@ -48,11 +110,18 @@ namespace Spectator.Repository {
         }
 
         public Models.Environment get_current_environment () {
-            return envs.get (0);
+            return envs.get (current_env);
         }
 
         public void set_current_environment (Models.Environment env) {
-            // Do something
+            for(int i = 0; i < envs.size; i++) {
+                var e = envs.get (i);
+
+                if (e.name == env.name) {
+                    current_env = i;
+                    break;
+                }
+            }
         }
 
         public void create_environment (string name) throws RecordExistsError {

--- a/src/Repository/InMemoryEnvironment.vala
+++ b/src/Repository/InMemoryEnvironment.vala
@@ -22,13 +22,26 @@
 
 namespace Spectator.Repository {
     public class InMemoryEnvironment : IEnvironment, Object {
+        private Gee.ArrayList<Models.Environment> envs;
         public Gee.ArrayList<Models.Environment> get_environments () {
-            var envs = new Gee.ArrayList<Models.Environment> ();
-            envs.add (new Models.Environment ("My Environment"));
+            envs = new Gee.ArrayList<Models.Environment> ();
+            var env = new Models.Environment ("My Environment");
+            env.variables["id"] = "123";
+            env.variables["base_url"] = "http://localhost:3456";
+            envs.add (env);
             envs.add (new Models.Environment ("Development"));
             envs.add (new Models.Environment ("Woop"));
             
             return envs;
         }
+
+        public Models.Environment get_current_environment () {
+            return envs.get (0);
+        }
+
+        public void set_current_environment (Models.Environment env) {
+            // Do something
+        }
+
     }
 }

--- a/src/Repository/InMemoryEnvironment.vala
+++ b/src/Repository/InMemoryEnvironment.vala
@@ -19,29 +19,16 @@
 * Authored by: Marvin Ahlgrimm <marv.ahlgrimm@gmail.com>
 */
 
-namespace Spectator.Dialogs {
-    public class Environments : Gtk.Dialog {
-        public Environments (Gtk.Window parent) {
-            title = _("Environments");
-            border_width = 5;
-            deletable = false;
-            resizable = false;
-            transient_for = parent;
-            modal = true;
 
-            add_button (_("Close"), Gtk.ResponseType.CLOSE);
-
-            response.connect ((source, id) => {
-                destroy ();
-            });
-
-            var content = get_content_area () as Gtk.Box;
-
-            content.width_request = 675;
-            content.height_request = 460;
-
-            content.margin = 15;
-            content.margin_top = 0;
+namespace Spectator.Repository {
+    public class InMemoryEnvironment : IEnvironment, Object {
+        public Gee.ArrayList<Models.Environment> get_environments () {
+            var envs = new Gee.ArrayList<Models.Environment> ();
+            envs.add (new Models.Environment ("My Environment"));
+            envs.add (new Models.Environment ("Development"));
+            envs.add (new Models.Environment ("Woop"));
+            
+            return envs;
         }
     }
 }

--- a/src/Repository/InMemoryEnvironment.vala
+++ b/src/Repository/InMemoryEnvironment.vala
@@ -65,6 +65,14 @@ namespace Spectator.Repository {
             return envs;
         }
 
+        public Models.Variable? get_variables_in_current_environment_by_name (string variable_name) {
+            return get_variables_in_environment_by_name ("current_env", variable_name);
+        }
+        
+        public Models.Variable? get_variables_in_environment_by_name (string env_name, string variable_name) {
+            return new Models.Variable ("asd", "asd");
+        }
+
         public Gee.ArrayList<Models.Variable> get_environment_variables (string env_name) {
             foreach (var env in envs) {
                 if (env.name == env_name) {

--- a/src/Repository/SQLiteEnvironment.vala
+++ b/src/Repository/SQLiteEnvironment.vala
@@ -311,17 +311,8 @@ namespace Spectator.Repository {
                     create_environment (default_env_name);
                     env = get_environment_by_name (default_env_name);
                 } catch (RecordExistsError error) {
-                    try {
-                        // Retry in case Default Environment could not be created
-                        default_env_name = default_env_name + " 2";
-                        create_environment (default_env_name);
-                        env = get_environment_by_name (default_env_name);
-                    } catch (RecordExistsError error) {
-                        // Something more funamentally went wrong and Spectator should not
-                        // recover from this
-                        stderr.printf ("Error loading current environment\n");
-                        Process.exit(1);
-                    }
+                    set_current_environment (new Models.Environment (default_env_name));
+                    env = get_environment_by_name (default_env_name);
                 }
             }
             

--- a/src/Repository/SQLiteEnvironment.vala
+++ b/src/Repository/SQLiteEnvironment.vala
@@ -1,0 +1,360 @@
+/*
+* Copyright (c) 2021 Marvin Ahlgrimm (https://github.com/treagod)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 2 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*
+* Authored by: Marvin Ahlgrimm <marv.ahlgrimm@gmail.com>
+*/
+
+namespace Spectator.Repository {
+    public class SQLiteEnvironment : IEnvironment, Object {
+        private weak Sqlite.Database db;
+        
+        public SQLiteEnvironment (Sqlite.Database d) {
+            db = d;
+        }
+
+        public Gee.ArrayList<Models.Environment> get_environments () {
+            var environments = new Gee.ArrayList<Models.Environment> ();
+            var query = """
+            SELECT name, created_at
+            FROM Environment
+            ORDER BY created_at ASC;
+            """;
+            Sqlite.Statement stmt;
+            int rc = db.prepare_v2 (query, query.length, out stmt);
+
+            if (rc == Sqlite.ERROR) {
+                warning ("Could not load environment\n");
+                return environments;
+            }
+
+            int cols = stmt.column_count ();
+            
+            while (stmt.step () == Sqlite.ROW) {
+                var environment = new Models.Environment.empty ();
+
+                for (int i = 0; i < cols; i++) {
+                    string col_name = stmt.column_name (i) ?? "<none>";
+
+                    switch (col_name) {
+                        case "name":
+                            environment.name = stmt.column_text (i);
+                            break;
+                        case "created_at":
+                            environment.created_at = new DateTime.from_unix_utc (stmt.column_int (i));
+                            break;
+                    }
+                }
+                environments.add (environment);
+            }
+
+            return environments;
+        }
+
+        public void add_variable_to_environment (string env_name) {
+            var query = """INSERT INTO Variable
+            (id, "key", value, created_at, environment_name)
+            VALUES($ID, '', '', $CREATED_AT, $ENV_NAME);            
+            """;
+
+            Sqlite.Statement stmt;
+            int rc = db.prepare_v2 (query, query.length, out stmt);
+
+            if (rc == Sqlite.ERROR) {
+                warning ("Could not create environment\n");
+                return;
+            }
+
+
+            var uuid = Uuid.string_random ();
+            var created_at = new DateTime.now_utc ();
+
+            int id_pos = stmt.bind_parameter_index ("$ID");
+            stmt.bind_text (id_pos, uuid);
+            int created_at_pos = stmt.bind_parameter_index ("$CREATED_AT");
+            stmt.bind_int64 (created_at_pos, created_at.to_unix ());
+            int name_pos = stmt.bind_parameter_index ("$ENV_NAME");
+            stmt.bind_text (name_pos, env_name);
+
+            if (stmt.step () != Sqlite.DONE) {
+                stderr.printf ("Error: %d: %s\n", db.errcode (), db.errmsg ());
+            }
+        }
+
+        public void delete_variable_value_in_environment (Models.Environment env, string variable_id) {
+            var query = """DELETE FROM Variable WHERE id=$ID and environment_name=$ENV_NAME;""";
+            Sqlite.Statement stmt;
+            int rc = db.prepare_v2 (query, query.length, out stmt);
+
+            if (rc == Sqlite.ERROR) {
+                warning ("Could not delete variables\n");
+                return;
+            }
+
+            int id_pos = stmt.bind_parameter_index ("$ID");
+            stmt.bind_text (id_pos, variable_id);
+
+            int name_pos = stmt.bind_parameter_index ("$ENV_NAME");
+            stmt.bind_text (name_pos, env.name);
+
+            if (stmt.step () != Sqlite.DONE) {
+                // Do something
+            } 
+        }
+
+        public Gee.ArrayList<Models.Variable> get_environment_variables (string env_name) {
+            var variables = new Gee.ArrayList<Models.Variable> ();
+            var query = """SELECT id, "key", value, created_at 
+            FROM Variable
+            WHERE Variable.environment_name == $ENV_NAME;""";
+            Sqlite.Statement stmt;
+            int rc = db.prepare_v2 (query, query.length, out stmt);
+
+            if (rc == Sqlite.ERROR) {
+                warning ("Could not load variables\n");
+                return variables;
+            }
+
+            int name_pos = stmt.bind_parameter_index ("$ENV_NAME");
+            stmt.bind_text (name_pos, env_name);
+
+            int cols = stmt.column_count ();
+            while (stmt.step () == Sqlite.ROW) {
+                var variable = new Models.Variable.empty ();
+                for (int i = 0; i < cols; i++) {
+                    string col_name = stmt.column_name (i) ?? "<none>";
+
+                    switch (col_name) {
+                        case "created_at":
+                            variable.created_at = new DateTime.from_unix_utc (stmt.column_int (i));
+                            break;
+                        case "id":
+                            variable.id = stmt.column_text (i) ;
+                            break;
+                        case "key":
+                            variable.key = stmt.column_text (i) ;
+                            break;
+                        case "value":
+                            variable.val = stmt.column_text (i) ;
+                            break;
+                    }
+                }
+                variables.add (variable);
+            }
+
+            return variables;
+        }
+
+        public Models.Variable? get_variables_in_current_environment_by_name (string variable_name) {
+            return get_variables_in_environment_by_name (Settings.get_instance ().current_environment, variable_name);
+        }
+
+        public Models.Variable? get_variables_in_environment_by_name (string env_name, string variable_name) {
+            var query = """SELECT id, "key", value, created_at 
+            FROM Variable
+            WHERE Variable.key=$NAME AND Variable.environment_name=$ENV_NAME;""";
+            Sqlite.Statement stmt;
+            int rc = db.prepare_v2 (query, query.length, out stmt);
+
+            if (rc == Sqlite.ERROR) {
+                warning ("Could not load variables\n");
+                return null;
+            }
+
+            int name_pos = stmt.bind_parameter_index ("$ENV_NAME");
+            stmt.bind_text (name_pos, env_name);
+
+            int id_pos = stmt.bind_parameter_index ("$NAME");
+            stmt.bind_text (id_pos, variable_name);
+
+            int cols = stmt.column_count ();
+            while (stmt.step () == Sqlite.ROW) {
+                var variable = new Models.Variable.empty ();
+                for (int i = 0; i < cols; i++) {
+                    string col_name = stmt.column_name (i) ?? "<none>";
+
+                    switch (col_name) {
+                        case "created_at":
+                            variable.created_at = new DateTime.from_unix_utc (stmt.column_int (i));
+                            break;
+                        case "id":
+                            variable.id = stmt.column_text (i) ;
+                            break;
+                        case "key":
+                            variable.key = stmt.column_text (i) ;
+                            break;
+                        case "value":
+                            variable.val = stmt.column_text (i) ;
+                            break;
+                    }
+                }
+                return variable;
+            }
+
+            return null;
+        }
+
+        public void update_variable_name_in_environment (Models.Environment env, string id, string key) {
+            var query = """UPDATE Variable
+            SET "key"=$KEY
+            WHERE id=$ID AND  environment_name=$ENV_NAME;            
+            """; 
+
+            Sqlite.Statement stmt;
+            int rc = db.prepare_v2 (query, query.length, out stmt);
+
+            if (rc == Sqlite.ERROR) {
+                warning ("Could not updaet load variable key\n");
+                return;
+            }
+
+            int id_pos = stmt.bind_parameter_index ("$ID");
+            stmt.bind_text (id_pos, id);
+
+            int name_pos = stmt.bind_parameter_index ("$ENV_NAME");
+            stmt.bind_text (name_pos, env.name);
+
+            int key_pos = stmt.bind_parameter_index ("$KEY");
+            stmt.bind_text (key_pos, key);
+            if (stmt.step () != Sqlite.DONE) {
+                // Do something
+            } 
+        }
+
+        public void update_variable_value_in_environment (Models.Environment env, string id, string value) {
+            var query = """UPDATE Variable
+            SET "value"=$VALUE
+            WHERE id=$ID AND  environment_name=$ENV_NAME;            
+            """; 
+
+            Sqlite.Statement stmt;
+            int rc = db.prepare_v2 (query, query.length, out stmt);
+
+            if (rc == Sqlite.ERROR) {
+                warning ("Could not updaet load variable value\n");
+                return;
+            }
+
+            int id_pos = stmt.bind_parameter_index ("$ID");
+            stmt.bind_text (id_pos, id);
+
+            int name_pos = stmt.bind_parameter_index ("$ENV_NAME");
+            stmt.bind_text (name_pos, env.name);
+
+            int value_pos = stmt.bind_parameter_index ("$VALUE");
+            stmt.bind_text (value_pos, value);
+            if (stmt.step () != Sqlite.DONE) {
+                // Do something
+            } 
+        }
+
+        public Models.Environment? get_environment_by_name (string name) {
+            var query = """
+            SELECT name, created_at
+            FROM Environment
+            WHERE Environment.name = $NAME;""";
+            Sqlite.Statement stmt;
+            int rc = db.prepare_v2 (query, query.length, out stmt);
+
+            if (rc == Sqlite.ERROR) {
+                warning ("Could not load environment\n");
+                return null;
+            }
+
+            int name_pos = stmt.bind_parameter_index ("$NAME");
+            stmt.bind_text (name_pos, name);
+
+            int cols = stmt.column_count ();
+            while (stmt.step () == Sqlite.ROW) {
+                var environment = new Models.Environment.empty ();
+                for (int i = 0; i < cols; i++) {
+                    string col_name = stmt.column_name (i) ?? "<none>";
+
+                    switch (col_name) {
+                        case "created_at":
+                            environment.created_at = new DateTime.from_unix_utc (stmt.column_int (i));
+                            break;
+                        case "name":
+                            environment.name = stmt.column_text (i) ;
+                            break;
+                    }
+                }
+                return environment;
+            }
+
+            return null;
+        }
+
+        public Models.Environment get_current_environment () {
+            var settings = Settings.get_instance ();
+
+            var env = get_environment_by_name (settings.current_environment);
+
+            if (env == null) {
+                var default_env_name = _("Default Environment");
+                
+                try {
+                    create_environment (default_env_name);
+                    env = get_environment_by_name (default_env_name);
+                } catch (RecordExistsError error) {
+                    try {
+                        // Retry in case Default Environment could not be created
+                        default_env_name = default_env_name + " 2";
+                        create_environment (default_env_name);
+                        env = get_environment_by_name (default_env_name);
+                    } catch (RecordExistsError error) {
+                        // Something more funamentally went wrong and Spectator should not
+                        // recover from this
+                        stderr.printf ("Error loading current environment\n");
+                        Process.exit(1);
+                    }
+                }
+            }
+            
+            return env;
+        }
+
+        public void set_current_environment (Models.Environment env) {
+            Settings.get_instance ().current_environment = env.name;
+        }
+
+        public void create_environment (string name) throws RecordExistsError {
+            Sqlite.Statement stmt;
+            var insert_query = """INSERT INTO Environment
+            (name, created_at)
+            VALUES($NAME, $CREATED_AT);
+            """;
+
+            int ec = db.prepare_v2 (insert_query, insert_query.length, out stmt);
+            if (ec != Sqlite.OK) {
+                stderr.printf ("Error: %d: %s\n", db.errcode (), db.errmsg ());
+            }
+
+            int name_pos = stmt.bind_parameter_index ("$NAME");
+            int created_at_pos = stmt.bind_parameter_index ("$CREATED_AT");
+
+            var created_at = new DateTime.now_utc ();
+
+            stmt.bind_text (name_pos, name);
+            stmt.bind_int64 (created_at_pos, created_at.to_unix ());
+
+            if (stmt.step () != Sqlite.DONE) {
+                throw new RecordExistsError.CODE_1A ("%s", db.errmsg ());
+            } 
+        }
+    }
+}

--- a/src/Repository/meson.build
+++ b/src/Repository/meson.build
@@ -1,6 +1,7 @@
 sources += files(
     'IEnvironment.vala',
     'InMemoryEnvironment.vala',
+    'SQLiteEnvironment.vala',
 
 	'IRequest.vala',
     'SQLiteRequest.vala',

--- a/src/Repository/meson.build
+++ b/src/Repository/meson.build
@@ -1,4 +1,7 @@
 sources += files(
+    'IEnvironment.vala',
+    'InMemoryEnvironment.vala',
+
 	'IRequest.vala',
     'SQLiteRequest.vala',
 

--- a/src/Services/SendingService.vala
+++ b/src/Services/SendingService.vala
@@ -24,10 +24,8 @@ namespace Spectator {
         public signal void request_script_output (uint id, string str, Services.ConsoleMessageType mt);
         private Gee.HashMap<uint, Services.RequestAction> running_actions;
         private Services.ScriptRuntime javascript_runtime;
-        private weak Repository.IEnvironment environments;
 
-        public SendingService (Repository.IEnvironment envs) {
-            this.environments = envs;
+        public SendingService () {
             this.running_actions = new Gee.HashMap<uint, Services.RequestAction> ();
             this.javascript_runtime = new Services.ScriptRuntime ();
         }

--- a/src/Services/SendingService.vala
+++ b/src/Services/SendingService.vala
@@ -24,8 +24,10 @@ namespace Spectator {
         public signal void request_script_output (uint id, string str, Services.ConsoleMessageType mt);
         private Gee.HashMap<uint, Services.RequestAction> running_actions;
         private Services.ScriptRuntime javascript_runtime;
+        private weak Repository.IEnvironment environments;
 
-        public SendingService () {
+        public SendingService (Repository.IEnvironment envs) {
+            this.environments = envs;
             this.running_actions = new Gee.HashMap<uint, Services.RequestAction> ();
             this.javascript_runtime = new Services.ScriptRuntime ();
         }

--- a/src/Services/Settings.vala
+++ b/src/Services/Settings.vala
@@ -49,6 +49,7 @@ namespace Spectator {
         public string font { get; set; }
         public bool use_default_font { get; set; }
         public string editor_scheme { get; set; }
+        public string current_environment { get; set; }
 
 
         public static Settings get_instance () {

--- a/src/Services/UrlAttributeEngine.vala
+++ b/src/Services/UrlAttributeEngine.vala
@@ -43,6 +43,10 @@ namespace Spectator.Services {
             this.url_entry.delete_text.connect (handle_variable_deletion);
         }
 
+        public void insert_variable (string variable_name) {
+            url_entry.insert_at_cursor ("#{%s}".printf (variable_name));
+        }
+
         private void handle_variable_deletion (int start_pos, int end_pos) {
             var deleted_text = this.url_entry.text.substring(start_pos, end_pos - start_pos);
 

--- a/src/Services/UrlAttributeEngine.vala
+++ b/src/Services/UrlAttributeEngine.vala
@@ -34,13 +34,50 @@ namespace Spectator.Services {
         }
 
         private weak Gtk.Entry url_entry;
+        private bool adjust_cursor;
 
         public UrlVariableEngine (Gtk.Entry url_entry) {
             this.url_entry = url_entry;
-            this.url_entry.changed.connect (() => {
-                update_highlighting ();
-            });
+            this.adjust_cursor = false;
+            this.url_entry.changed.connect (update_highlighting);
             this.url_entry.delete_text.connect (handle_variable_deletion);
+            this.url_entry.move_cursor.connect (skip_variable_hidden_character);
+        }
+
+        // Skips '#{' or '}' on cursor movement, so that the user does not notice,
+        // that there are extra characters
+        private void skip_variable_hidden_character (Gtk.MovementStep step, int count, bool extend_selection) {
+            // Locking so the cursor movement after readjustment won't be processed (prevents recursion)
+            if (adjust_cursor) return;
+            if (count == 1) {
+                // Cursor movement to the right
+                if (this.url_entry.text[this.url_entry.cursor_position] == '}') {
+                    adjust_cursor = true;
+                    this.url_entry.move_cursor (step, 1, extend_selection);
+                    adjust_cursor = false;
+                } else if (
+                    this.url_entry.text[this.url_entry.cursor_position] == '#' &&
+                    this.url_entry.text[this.url_entry.cursor_position + 1] == '{'
+                ) {
+                    adjust_cursor = true;
+                    this.url_entry.move_cursor (step, 2, extend_selection);
+                    adjust_cursor = false;
+                }
+            } else if (count == -1) {
+                // Cursor movement to the left
+                if (this.url_entry.text[this.url_entry.cursor_position - 1] == '}') {
+                    adjust_cursor = true;
+                    this.url_entry.move_cursor (step, -1, extend_selection);
+                    adjust_cursor = false;
+                } else if (
+                    this.url_entry.text[this.url_entry.cursor_position - 1] == '{' &&
+                    this.url_entry.text[this.url_entry.cursor_position - 2] == '#'
+                ) {
+                    adjust_cursor = true;
+                    this.url_entry.move_cursor (step, -2, extend_selection);
+                    adjust_cursor = false;
+                }
+            }
         }
 
         public void insert_variable (string variable_name) {

--- a/src/Services/VariableResolver.vala
+++ b/src/Services/VariableResolver.vala
@@ -20,7 +20,7 @@
 */
 
 namespace Spectator.Services {
-    public class ResolveResult {
+    public class ResolveResult {        
         public Gee.ArrayList<string> unresolved_variable_names { get; private set; }
         public string resolved_text { get; private set; }
 
@@ -41,7 +41,7 @@ namespace Spectator.Services {
         public VariableResolver (Repository.IEnvironment envs) {
             environments = envs;
             try {
-                variable_regex = new Regex("#{(.*)}", RegexCompileFlags.UNGREEDY);
+                variable_regex = new Regex("#{(.*)}", RegexCompileFlags.UNGREEDY); // Todo: Cache Regex
             } catch (RegexError error) {
                 stderr.printf ("Unable to initialize regex\n");
                 Process.exit(1);
@@ -60,14 +60,12 @@ namespace Spectator.Services {
             return null;
         }
 
-        public ResolveResult resolve_variables (string url) {
-            // TODO: Refactor. Just proof of concept
+        public ResolveResult resolve_variables (string text) {
             try {
                 var errors = new Gee.ArrayList<string> ();
-                var resolved_text = variable_regex.replace_eval (url, url.length, 0, 0, (match_info, builder) => {
+                var resolved_text = variable_regex.replace_eval (text, text.length, 0, 0, (match_info, builder) => {
                     var variable_name = match_info.fetch (1);
-                    var current_environment = environments.get_current_environment ();
-                    var variable = current_environment.get_variable (match_info.fetch (1));
+                    var variable = environments.get_variables_in_current_environment_by_name (variable_name);
     
                     if (variable != null) {
                         builder.append (variable.val);

--- a/src/Services/VariableResolver.vala
+++ b/src/Services/VariableResolver.vala
@@ -1,0 +1,60 @@
+/*
+* Copyright (c) 2021 Marvin Ahlgrimm (https://github.com/treagod)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 2 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*
+* Authored by: Marvin Ahlgrimm <marv.ahlgrimm@gmail.com>
+*/
+
+namespace Spectator.Services {
+    public class VariableResolver {
+        private weak Repository.IEnvironment environments;
+        Regex variable_regex;
+
+        public VariableResolver (Repository.IEnvironment envs) {
+            environments = envs;
+            try {
+                variable_regex = new Regex("#{(.*)}", RegexCompileFlags.UNGREEDY);
+            } catch (RegexError error) {
+                stderr.printf ("Unable to initialize regex\n");
+                Process.exit(1);
+            }
+        }
+
+        public void resolve_request_variables (ref Models.Request request) {
+            request.uri = resolve_variables (request.uri);
+        }
+
+        public string resolve_variables (string url) {
+            // TODO: Refactor. Just proof of concept
+            try {
+                return variable_regex.replace_eval (url, url.length, 0, 0, (match_info, builder) => {
+                    var current_environment = environments.get_current_environment ();
+                    var variable_name = current_environment.get_variable (match_info.fetch (1));
+    
+                    if (variable_name != null) {
+                        builder.append (variable_name);
+                    } else {
+                        builder.append ("UNDEF_VARIABLE");
+                    }
+                    return false;
+                });
+            } catch (RegexError error) {
+                return "Could not parse URL";
+            }
+        }
+    }
+}

--- a/src/Services/WindowBuilder.vala
+++ b/src/Services/WindowBuilder.vala
@@ -1,0 +1,44 @@
+/*
+* Copyright (c) 2021 Marvin Ahlgrimm (https://github.com/treagod)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 2 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*
+* Authored by: Marvin Ahlgrimm <marv.ahlgrimm@gmail.com>
+*/
+
+namespace Spectator.Services {
+    public class WindowBuilder {
+        private Window window;
+        private Repository.IRequest request_repository;
+        private Repository.ICollection collection_repository;
+        private Repository.ICustomOrder order_repository;
+        private Repository.IEnvironment environment_repository;
+        public WindowBuilder (Repository.IRequest rr,
+            Repository.ICollection cr,
+            Repository.ICustomOrder or,
+            Repository.IEnvironment er) {
+            request_repository = rr;
+            collection_repository = cr;
+            order_repository = or;
+            environment_repository = er;
+        }
+
+        public Window build_window (Gtk.Application app) {
+            window = new Window (app, request_repository, collection_repository, order_repository, environment_repository);
+            return window;
+        }
+    }
+}

--- a/src/Services/meson.build
+++ b/src/Services/meson.build
@@ -2,6 +2,7 @@ sources += files(
 	'Utilities.vala',
     'ScriptWriter.vala',
     'VariableResolver.vala',
+    'WindowBuilder.vala',
 	'Settings.vala',
 	'JsonSerializer.vala',
 	'JsonDeserializer.vala',

--- a/src/Services/meson.build
+++ b/src/Services/meson.build
@@ -1,6 +1,7 @@
 sources += files(
 	'Utilities.vala',
     'ScriptWriter.vala',
+    'VariableResolver.vala',
 	'Settings.vala',
 	'JsonSerializer.vala',
 	'JsonDeserializer.vala',

--- a/src/Widgets/Content.vala
+++ b/src/Widgets/Content.vala
@@ -148,6 +148,10 @@ namespace Spectator.Widgets {
                 this.set_error (error);
             });
 
+            request.clear_error.connect (() => {
+                this.reset_infobar ();
+            });
+
             request.method_changed.connect ((method) => {
                 method_changed (this.active_id, method);
             });

--- a/src/Widgets/Content.vala
+++ b/src/Widgets/Content.vala
@@ -141,16 +141,12 @@ namespace Spectator.Widgets {
             });
 
             request.request_sent.connect ((id) => {
-                this.request_sent (id);
+                request_sent (id);
             });
 
-            request.send_error.connect ((error) => {
-                this.set_error (error);
-            });
+            request.send_error.connect (set_error);
 
-            request.clear_error.connect (() => {
-                this.reset_infobar ();
-            });
+            request.clear_error.connect (reset_infobar);
 
             request.method_changed.connect ((method) => {
                 method_changed (this.active_id, method);

--- a/src/Widgets/HeaderBar.vala
+++ b/src/Widgets/HeaderBar.vala
@@ -34,6 +34,7 @@ namespace Spectator.Widgets {
         }
 
         public signal void preference_clicked ();
+        public signal void environments_clicked ();
 
         public HeaderBar () {
             Object (
@@ -49,16 +50,18 @@ namespace Spectator.Widgets {
             _new_collection = new Gtk.Button.from_icon_name ("folder-new", Gtk.IconSize.LARGE_TOOLBAR);
             _new_collection.tooltip_text = _("Create Collection");
 
-            var preference_button = new Gtk.Button.from_icon_name ("open-menu", Gtk.IconSize.LARGE_TOOLBAR);
-            preference_button.tooltip_text = _("Preferences");
-
             var preference_dialog_button = new Gtk.ModelButton ();
-            preference_button.label = _("Open preferences");
+            preference_dialog_button.text = _("Preferences");
             preference_dialog_button.show_all ();
+
+            var environment_dialog_button = new Gtk.ModelButton ();
+            environment_dialog_button.text = _("Environments");
+            environment_dialog_button.show_all ();
 
             var menu_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 2);
 
             menu_box.add (preference_dialog_button);
+            menu_box.add (environment_dialog_button);
             menu_box.show_all ();
 
             var menu = new Gtk.Popover (null);
@@ -70,8 +73,12 @@ namespace Spectator.Widgets {
             app_menu.popover = menu;
             app_menu.show_all ();
 
-            preference_button.clicked.connect (() => {
-                // preference_clicked ();
+            preference_dialog_button.clicked.connect (() => {
+                preference_clicked ();
+            });
+
+            environment_dialog_button.clicked.connect (() => {
+                environments_clicked ();
             });
 
             title = Constants.RELEASE_NAME;

--- a/src/Widgets/HeaderBar.vala
+++ b/src/Widgets/HeaderBar.vala
@@ -52,15 +52,33 @@ namespace Spectator.Widgets {
             var preference_button = new Gtk.Button.from_icon_name ("open-menu", Gtk.IconSize.LARGE_TOOLBAR);
             preference_button.tooltip_text = _("Preferences");
 
+            var preference_dialog_button = new Gtk.ModelButton ();
+            preference_button.label = _("Open preferences");
+            preference_dialog_button.show_all ();
+
+            var menu_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 2);
+
+            menu_box.add (preference_dialog_button);
+            menu_box.show_all ();
+
+            var menu = new Gtk.Popover (null);
+            menu.add (menu_box);
+
+            var app_menu = new Gtk.MenuButton ();
+            app_menu.image = new Gtk.Image.from_icon_name ("open-menu", Gtk.IconSize.LARGE_TOOLBAR);
+            app_menu.tooltip_text = _("Menu");
+            app_menu.popover = menu;
+            app_menu.show_all ();
+
             preference_button.clicked.connect (() => {
-                preference_clicked ();
+                // preference_clicked ();
             });
 
             title = Constants.RELEASE_NAME;
             subtitle = "";
             pack_start (_new_request);
             pack_start (_new_collection);
-            pack_end (preference_button);
+            pack_end (app_menu);
         }
     }
 }

--- a/src/Widgets/Request/Container.vala
+++ b/src/Widgets/Request/Container.vala
@@ -160,7 +160,7 @@ namespace Spectator.Widgets.Request {
         }
 
         private UrlEntry create_url_entry () {
-            var url_entry = new UrlEntry (window);
+            var url_entry = new UrlEntry (window.environment_service);
             url_entry.margin_bottom = 7;
 
             url_entry.url_changed.connect ((url) => {

--- a/src/Widgets/Request/Container.vala
+++ b/src/Widgets/Request/Container.vala
@@ -22,6 +22,7 @@
 namespace Spectator.Widgets.Request {
     class Container : Gtk.Box, Interface {
         private UrlEntry url_entry;
+        private weak Window window;
         private KeyValueList header_view;
         private BodyView body_view;
         private KeyValueList url_params_view;
@@ -47,7 +48,8 @@ namespace Spectator.Widgets.Request {
             margin = 4;
         }
 
-        public Container () {
+        public Container (Window win) {
+            window = win;
             this.header_view = create_header_view ();
             this.url_params_view = create_url_params_view ();
             this.url_entry = create_url_entry ();
@@ -158,7 +160,7 @@ namespace Spectator.Widgets.Request {
         }
 
         private UrlEntry create_url_entry () {
-            var url_entry = new UrlEntry ();
+            var url_entry = new UrlEntry (window);
             url_entry.margin_bottom = 7;
 
             url_entry.url_changed.connect ((url) => {

--- a/src/Widgets/Request/Popover.vala
+++ b/src/Widgets/Request/Popover.vala
@@ -1,0 +1,97 @@
+/*
+* Copyright (c) 2021 Marvin Ahlgrimm (https://github.com/treagod)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 2 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*
+* Authored by: Marvin Ahlgrimm <marv.ahlgrimm@gmail.com>
+*/
+
+namespace Spectator.Widgets.Request {
+    public class Popover : Gtk.Popover {
+        private Gdk.Rectangle r;
+        private Gtk.Box popover_box;
+        private weak Repository.IEnvironment environments;
+        private weak Gtk.Entry entry;
+        private Gtk.Box no_variable_message;
+
+        public signal void variable_selected (string name);
+
+        public Popover (Gtk.Entry relative, Repository.IEnvironment envs) {
+            relative_to = relative;
+            position = Gtk.PositionType.BOTTOM;
+            entry = relative;
+            environments = envs;
+            popover_box = new Gtk.Box(Gtk.Orientation.VERTICAL, 0);
+            popover_box.margin = 3;
+
+            closed.connect (() => {
+                foreach (var child in popover_box.get_children ()) {
+                    popover_box.remove (child);
+                }
+            });
+            
+            init_no_variable_message ();
+            add (popover_box);
+        }
+
+        public void show_variables () {
+            calculate_position (
+                out r,
+                entry.get_layout (),
+                entry.text_index_to_layout_index (entry.cursor_position)
+            );
+            set_pointing_to (r);
+
+            var current_environment = environments.get_current_environment ();
+
+            var variables_exists = false;
+
+            foreach (var variable_name in current_environment.get_variable_names ()) {
+                variables_exists = true;
+                var button = new Gtk.ModelButton ();
+                button.label = variable_name;
+                button.clicked.connect (() => {
+                    variable_selected (variable_name);
+                });
+                popover_box.add (button);
+            }
+
+            if (!variables_exists) {
+                popover_box.add (no_variable_message);
+            }
+
+            show_all ();
+            popup ();
+        }
+
+        private void calculate_position (out Gdk.Rectangle rectangle, Pango.Layout layout, int cursor_position) {
+            var rec = layout.index_to_pos (cursor_position + 1);
+            rectangle = Gdk.Rectangle ();
+            rectangle.height = 20;
+            rectangle.width = rec.width / Pango.SCALE;
+            rectangle.x = (rec.x / Pango.SCALE);
+            rectangle.y = 0;
+        }
+
+        private void init_no_variable_message () {
+            no_variable_message = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
+            no_variable_message.margin = 10;
+            var l = new Gtk.Label ("<i>No variables in current environment defined</i>");
+            l.use_markup = true;
+            no_variable_message.add (l);
+        }
+    }
+}

--- a/src/Widgets/Request/Popover.vala
+++ b/src/Widgets/Request/Popover.vala
@@ -59,12 +59,12 @@ namespace Spectator.Widgets.Request {
 
             var variables_exists = false;
 
-            foreach (var variable_name in current_environment.get_variable_names ()) {
+            foreach (var variable in environments.get_environment_variables (current_environment.name)) {
                 variables_exists = true;
                 var button = new Gtk.ModelButton ();
-                button.label = variable_name;
+                button.label = variable.key;
                 button.clicked.connect (() => {
-                    variable_selected (variable_name);
+                    variable_selected (variable.key);
                 });
                 popover_box.add (button);
             }

--- a/src/Widgets/Request/UrlEntry.vala
+++ b/src/Widgets/Request/UrlEntry.vala
@@ -67,8 +67,6 @@ namespace Spectator.Widgets.Request {
             popover.add (popover_box);
 
             url_entry.key_release_event.connect ((event) => {
-                notify_url_change (); // Todo: Only if not ctrl+space pressed?
-
                 if (event.state == Gdk.ModifierType.CONTROL_MASK && event.keyval == Gdk.Key.space) {
                     // Todo: Extract into variable engine?
                     var current_environment = window.environment_service.get_current_environment ();
@@ -85,12 +83,15 @@ namespace Spectator.Widgets.Request {
                         button.label = variable_name;
                         button.clicked.connect (() => {
                             variable_engine.insert_variable (variable_name);
+                            notify_url_change ();
                         });
                         popover_box.add (button);
                     }
 
                     popover.show_all ();
                     popover.popup ();
+                } else {
+                    notify_url_change ();
                 }
 
                 return true;

--- a/src/Widgets/RequestResponsePane.vala
+++ b/src/Widgets/RequestResponsePane.vala
@@ -74,7 +74,7 @@ namespace Spectator.Widgets {
             this.window = window;
             this.request_view = new Request.Container (window);
             this.current_response_view = new Response.Container ();
-            this.sending_service = new SendingService (window.environment_service);
+            this.sending_service = new SendingService ();
             response_views = new Gee.HashMap<uint, Response.Container> ();
 
             this.sending_service.request_script_output.connect ((id, str, type) => {

--- a/src/Widgets/RequestResponsePane.vala
+++ b/src/Widgets/RequestResponsePane.vala
@@ -70,26 +70,6 @@ namespace Spectator.Widgets {
             }
         }
 
-        private string resolve_variables (string url) {
-            // TODO: Refactor. Just proof of concept
-            try {
-                var regex = new Regex("#{(.*)}", RegexCompileFlags.UNGREEDY);
-                return regex.replace_eval (url, url.length, 0, 0, (match_info, builder) => {
-                    var current_environment = window.environment_service.get_current_environment ();
-                    var variable_name = current_environment.get_variable (match_info.fetch (1));
-    
-                    if (variable_name != null) {
-                        builder.append (variable_name.key);
-                    } else {
-                        builder.append ("UNDEF_VARIABLE");
-                    }
-                    return false;
-                });
-            } catch (RegexError error) {
-                return "Could not parse URL";
-            }
-        }
-
         public RequestResponsePane (Spectator.Window window) {
             this.window = window;
             this.request_view = new Request.Container (window);

--- a/src/Widgets/RequestResponsePane.vala
+++ b/src/Widgets/RequestResponsePane.vala
@@ -71,7 +71,7 @@ namespace Spectator.Widgets {
 
         public RequestResponsePane (Spectator.Window window) {
             this.window = window;
-            this.request_view = new Request.Container ();
+            this.request_view = new Request.Container (window);
             this.current_response_view = new Response.Container ();
             this.sending_service = new SendingService ();
             response_views = new Gee.HashMap<uint, Response.Container> ();

--- a/src/Widgets/Sidebar/Collection/Container.vala
+++ b/src/Widgets/Sidebar/Collection/Container.vala
@@ -200,7 +200,7 @@ namespace Spectator.Widgets.Sidebar.Collection {
         }
 
         public void add_request (Models.Request request) {
-            var request_list_item = new RequestListItem (request.id, request.name, request.uri, request.method);
+            var request_list_item = new RequestListItem (window.variable_resolver, request.id, request.name, request.uri, request.method);
             request_list_item.activate_drag_and_drop ();
 
             this.add (request_list_item);
@@ -232,7 +232,7 @@ namespace Spectator.Widgets.Sidebar.Collection {
         }
 
         public void add_collection (Models.Collection collection) {
-            var dropdown = new Dropdown (collection);
+            var dropdown = new Dropdown (window, collection);
 
             dropdown.item_edit.connect ((request) => {
                 item_edit (request);

--- a/src/Widgets/Sidebar/Collection/Dropdown.vala
+++ b/src/Widgets/Sidebar/Collection/Dropdown.vala
@@ -24,6 +24,7 @@ namespace Spectator.Widgets.Sidebar.Collection {
         public delegate void ItemIterator (RequestListItem item);
         private static string collection_open_icon = "folder-open";
         private static string collection_closed_icon = "folder";
+        private weak Window window;
 
         public signal void item_edit (Models.Request request);
         public signal void item_clone (Models.Request request);
@@ -90,7 +91,7 @@ namespace Spectator.Widgets.Sidebar.Collection {
         }
 
         public RequestListItem add_request (Models.Request request) {
-            var request_list_item = new RequestListItem (request.id, request.name, request.uri, request.method);
+            var request_list_item = new RequestListItem (window.variable_resolver, request.id, request.name, request.uri, request.method);
             request_list_item.activate_drag_and_drop ();
 
             this.item_box.add (request_list_item);
@@ -120,7 +121,8 @@ namespace Spectator.Widgets.Sidebar.Collection {
             return request_list_item;
         }
 
-        public Dropdown (Models.Collection collection) {
+        public Dropdown (Window win, Models.Collection collection) {
+            window = win;
             this.collection_id = collection.id;
             this.box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 3);
             this.item_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 2);

--- a/src/Widgets/Sidebar/Container.vala
+++ b/src/Widgets/Sidebar/Container.vala
@@ -31,6 +31,8 @@ namespace Spectator.Widgets.Sidebar {
 
     public class TitleBar : Gtk.Box {
         private Gtk.Label title;
+        private weak Window window;
+        private Gtk.Box environment_box;
         private string collection_title_text = _("My Enviroment");
         private string history_title_text = _("History");
 
@@ -55,7 +57,8 @@ namespace Spectator.Widgets.Sidebar {
             title_text = history_title_text;
         }
 
-        public TitleBar () {
+        public TitleBar (Window win) {
+            this.window = win;
             orientation = Gtk.Orientation.VERTICAL;
 
             title = new Gtk.Label (collection_title_text);
@@ -71,29 +74,9 @@ namespace Spectator.Widgets.Sidebar {
             box.halign = Gtk.Align.CENTER;
             var popover = new Gtk.Popover (down_arrow);
 
-            var pop_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 2);
-            var button = new Gtk.ModelButton ();
-                button.label = "My Environment";
-                button.clicked.connect (() => {
-                    title.label = "My Environement";
-                });
-                pop_box.add(button);
+            environment_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 2);
 
-                button = new Gtk.ModelButton ();
-                button.label = "Shourney";
-                button.clicked.connect (() => {
-                    title.label = "Shourney";
-                });
-                pop_box.add(button);
-
-                button = new Gtk.ModelButton ();
-                button.label = "My Website";
-                button.clicked.connect (() => {
-                    title.label = "My Website";
-                });
-                pop_box.add(button);
-                pop_box.show_all ();
-                popover.add (pop_box);
+            popover.add (environment_box);
 
             event_box.add (box);
             event_box.button_release_event.connect (() => {
@@ -136,6 +119,19 @@ namespace Spectator.Widgets.Sidebar {
         public void on_drag_leave (Gdk.DragContext context, uint time) {
             request_removed ();
         }
+
+        public void show_environments () {
+            foreach (var env in window.environment_service.get_environments ()) {
+                var button = new Gtk.ModelButton ();
+    
+                button.label = env.name;
+                button.clicked.connect (() => {
+                    title.label = env.name;
+                });
+                environment_box.add(button);
+                environment_box.show_all ();
+            }
+        }
     }
 
     public class Container : Gtk.Box {
@@ -166,8 +162,7 @@ namespace Spectator.Widgets.Sidebar {
             collection_scroll = new Gtk.ScrolledWindow (null, null);
             collection_scroll.hscrollbar_policy = Gtk.PolicyType.AUTOMATIC;
             collection_scroll.vscrollbar_policy = Gtk.PolicyType.AUTOMATIC;
-
-            titlebar = new TitleBar ();
+            titlebar = new TitleBar (window);
 
             orientation = Gtk.Orientation.VERTICAL;
             width_request = 265;
@@ -390,6 +385,7 @@ This can't be undone!""".printf (collection.name)),
         public void show_items () {
             this.show_collection_items ();
             this.show_history_items ();
+            this.titlebar.show_environments ();
         }
 
         public void show_collection_items () {

--- a/src/Widgets/Sidebar/Container.vala
+++ b/src/Widgets/Sidebar/Container.vala
@@ -33,7 +33,7 @@ namespace Spectator.Widgets.Sidebar {
         private Gtk.Label title;
         private weak Window window;
         private Gtk.Box environment_box;
-        private string collection_title_text = _("My Enviroment");
+        private string collection_title_text = _("Loading...");
         private string history_title_text = _("History");
 
         public signal void request_dropped (uint id);
@@ -131,6 +131,7 @@ namespace Spectator.Widgets.Sidebar {
                 environment_box.add(button);
                 environment_box.show_all ();
             }
+            title.label = window.environment_service.get_current_environment ().name;
         }
     }
 

--- a/src/Widgets/Sidebar/Container.vala
+++ b/src/Widgets/Sidebar/Container.vala
@@ -78,8 +78,15 @@ namespace Spectator.Widgets.Sidebar {
 
             popover.add (environment_box);
 
+            popover.closed.connect (() => {
+                environment_box.foreach ((w) => {
+                    environment_box.remove (w);
+                });
+            });
+
             event_box.add (box);
             event_box.button_release_event.connect (() => {
+                show_environments ();
                 popover.popup ();
                 return true;
             });
@@ -386,7 +393,6 @@ This can't be undone!""".printf (collection.name)),
         public void show_items () {
             this.show_collection_items ();
             this.show_history_items ();
-            this.titlebar.show_environments ();
         }
 
         public void show_collection_items () {

--- a/src/Widgets/Sidebar/Container.vala
+++ b/src/Widgets/Sidebar/Container.vala
@@ -31,14 +31,14 @@ namespace Spectator.Widgets.Sidebar {
 
     public class TitleBar : Gtk.Box {
         private Gtk.Label title;
-        private weak Window window;
+        private weak Repository.IEnvironment environments;
         private Gtk.Box environment_box;
-        private string collection_title_text = _("Loading...");
-        private string history_title_text = _("History");
+        public bool source_destination;
 
         public signal void request_dropped (uint id);
         public signal void request_dragged ();
         public signal void request_removed ();
+        public signal void environment_changed ();
 
         public string title_text {
             get {
@@ -49,19 +49,12 @@ namespace Spectator.Widgets.Sidebar {
             }
         }
 
-        public void show_collection () {
-            title_text = collection_title_text;
-        }
-
-        public void show_history () {
-            title_text = history_title_text;
-        }
-
-        public TitleBar (Window win) {
-            this.window = win;
+        public TitleBar (Repository.IEnvironment envs) {
+            environments = envs;
             orientation = Gtk.Orientation.VERTICAL;
+            source_destination = true;
 
-            title = new Gtk.Label (collection_title_text);
+            title = new Gtk.Label (envs.get_current_environment ().name);
             title.get_style_context ().add_class ("h2");
             title.halign = Gtk.Align.CENTER;
             title.margin = 5;
@@ -109,7 +102,7 @@ namespace Spectator.Widgets.Sidebar {
         private void on_drag_data_received (Gdk.DragContext context, int x, int y,
             Gtk.SelectionData selection_data, uint target_type, uint time) {
             /* Drag & Drop is only activated for collection mode */
-            if (title.label == collection_title_text) {
+            if (source_destination) {
                 var row = ((Gtk.Widget[]) selection_data.get_data ())[0];
                 var source = (RequestListItem) row;
 
@@ -128,17 +121,19 @@ namespace Spectator.Widgets.Sidebar {
         }
 
         public void show_environments () {
-            foreach (var env in window.environment_service.get_environments ()) {
+            foreach (var env in environments.get_environments ()) {
                 var button = new Gtk.ModelButton ();
     
                 button.label = env.name;
                 button.clicked.connect (() => {
                     title.label = env.name;
+                    environments.set_current_environment (env);
+                    environment_changed ();
                 });
                 environment_box.add(button);
                 environment_box.show_all ();
             }
-            title.label = window.environment_service.get_current_environment ().name;
+            title.label = environments.get_current_environment ().name;
         }
     }
 
@@ -170,7 +165,7 @@ namespace Spectator.Widgets.Sidebar {
             collection_scroll = new Gtk.ScrolledWindow (null, null);
             collection_scroll.hscrollbar_policy = Gtk.PolicyType.AUTOMATIC;
             collection_scroll.vscrollbar_policy = Gtk.PolicyType.AUTOMATIC;
-            titlebar = new TitleBar (window);
+            titlebar = new TitleBar (window.environment_service);
 
             orientation = Gtk.Orientation.VERTICAL;
             width_request = 265;
@@ -309,6 +304,10 @@ This can't be undone!""".printf (collection.name)),
                 this.show_items ();
             });
 
+            titlebar.environment_changed.connect (() => {
+                this.show_items ();
+            });
+
             titlebar.request_dragged.connect (() => {
                 collection.drag_reavel_top ();
             });
@@ -341,10 +340,10 @@ This can't be undone!""".printf (collection.name)),
             mode_buttons.mode_changed.connect (() => {
                 if (mode_buttons.selected == 0) {
                     stack.set_visible_child (collection_scroll);
-                    titlebar.show_collection ();
+                    titlebar.source_destination = true;
                 } else {
                     stack.set_visible_child (history_scroll);
-                    titlebar.show_history ();
+                    titlebar.source_destination = false;
                 }
             });
 
@@ -373,13 +372,13 @@ This can't be undone!""".printf (collection.name)),
         public void show_history () {
             mode_buttons.selected = 1;
             stack.set_visible_child (history_scroll);
-            titlebar.show_history ();
+            titlebar.source_destination = false;
         }
 
         public void show_collection () {
             mode_buttons.selected = 0;
             stack.set_visible_child (collection_scroll);
-            titlebar.show_collection ();
+            titlebar.source_destination = true;
         }
 
         public void add_collection (Models.Collection model) {

--- a/src/Widgets/Sidebar/Container.vala
+++ b/src/Widgets/Sidebar/Container.vala
@@ -31,7 +31,7 @@ namespace Spectator.Widgets.Sidebar {
 
     public class TitleBar : Gtk.Box {
         private Gtk.Label title;
-        private string collection_title_text = _("Collections");
+        private string collection_title_text = _("My Enviroment");
         private string history_title_text = _("History");
 
         public signal void request_dropped (uint id);
@@ -62,11 +62,49 @@ namespace Spectator.Widgets.Sidebar {
             title.get_style_context ().add_class ("h2");
             title.halign = Gtk.Align.CENTER;
             title.margin = 5;
+            var down_arrow = new Gtk.Image.from_icon_name ("pan-down-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
+            var box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
+            var event_box = new Gtk.EventBox ();
+            box.add(title);
+            box.add (down_arrow);
+            box.hexpand = true;
+            box.halign = Gtk.Align.CENTER;
+            var popover = new Gtk.Popover (down_arrow);
+
+            var pop_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 2);
+            var button = new Gtk.ModelButton ();
+                button.label = "My Environment";
+                button.clicked.connect (() => {
+                    title.label = "My Environement";
+                });
+                pop_box.add(button);
+
+                button = new Gtk.ModelButton ();
+                button.label = "Shourney";
+                button.clicked.connect (() => {
+                    title.label = "Shourney";
+                });
+                pop_box.add(button);
+
+                button = new Gtk.ModelButton ();
+                button.label = "My Website";
+                button.clicked.connect (() => {
+                    title.label = "My Website";
+                });
+                pop_box.add(button);
+                pop_box.show_all ();
+                popover.add (pop_box);
+
+            event_box.add (box);
+            event_box.button_release_event.connect (() => {
+                popover.popup ();
+                return true;
+            });
 
             var separator = new Gtk.Separator (Gtk.Orientation.HORIZONTAL);
             separator.margin_top = 2;
 
-            pack_start (title, true, true, 0);
+            pack_start (event_box, true, true, 0);
             pack_start (separator, true, true, 0);
             this.build_drag_and_drop ();
         }

--- a/src/Widgets/Sidebar/History/Container.vala
+++ b/src/Widgets/Sidebar/History/Container.vala
@@ -123,7 +123,7 @@ namespace Spectator.Widgets.Sidebar.History {
         }
 
         private void add_history_item (string key_date, Models.Request request) {
-            var request_list_item = new RequestListItem (request.id, request.name, request.uri, request.method);
+            var request_list_item = new RequestListItem (window.variable_resolver ,request.id, request.name, request.uri, request.method);
 
             request_list_item.clicked.connect ((event) => {
                 this.request_item_selected (request.id);

--- a/src/Widgets/Sidebar/Item.vala
+++ b/src/Widgets/Sidebar/Item.vala
@@ -172,10 +172,11 @@ namespace Spectator.Widgets.Sidebar {
             row.get_allocation (out alloc);
 
             var surface = new Cairo.ImageSurface (Cairo.Format.ARGB32, alloc.width, alloc.height);
+
+            // Draw border arround widget
             var cr = new Cairo.Context (surface);
             cr.set_source_rgba (0, 0, 0, 0.3);
             cr.set_line_width (1);
-
             cr.move_to (0, 0);
             cr.line_to (alloc.width, 0);
             cr.line_to (alloc.width, alloc.height);
@@ -183,6 +184,7 @@ namespace Spectator.Widgets.Sidebar {
             cr.line_to (0, 0);
             cr.stroke ();
 
+            // Set white overlay for widget
             cr.set_source_rgba (255, 255, 255, 0.5);
             cr.rectangle (0, 0, alloc.width, alloc.height);
             cr.fill ();

--- a/src/Widgets/Sidebar/Item.vala
+++ b/src/Widgets/Sidebar/Item.vala
@@ -241,8 +241,13 @@ namespace Spectator.Widgets.Sidebar {
         }
 
         private void set_formatted_uri (string request_url) {
+            var result = variable_resolver.resolve_variables (request_url);
             if (request_url.length > 0) {
-                url.label = "<small><i>" + escape_url (variable_resolver.resolve_variables (request_url)) + "</i></small>";
+                if (!result.has_errors ()) {
+                    url.label = "<small><i>" + escape_url (result.resolved_text) + "</i></small>";
+                } else {
+                    url.label = "<small><i><span color=\"#a10705\">" + escape_url (result.resolved_text) + "</span></i></small>";
+                }
             } else {
                 url.label = no_url;
             }

--- a/src/Widgets/Sidebar/Item.vala
+++ b/src/Widgets/Sidebar/Item.vala
@@ -28,6 +28,7 @@ namespace Spectator.Widgets.Sidebar {
         private Gtk.Label url;
         private Gtk.Revealer motion_revealer;
         private Gtk.Revealer content;
+        private weak Services.VariableResolver variable_resolver;
         public uint id { get; private set; }
 
         public signal void clicked ();
@@ -63,7 +64,8 @@ namespace Spectator.Widgets.Sidebar {
             }
         }
 
-        public RequestListItem (uint id, string name, string request_url, Models.Method request_method) {
+        public RequestListItem (Services.VariableResolver rsv, uint id, string name, string request_url, Models.Method request_method) {
+            variable_resolver = rsv;
             this.id = id;
             item_box = new Gtk.EventBox ();
             var info_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
@@ -240,7 +242,7 @@ namespace Spectator.Widgets.Sidebar {
 
         private void set_formatted_uri (string request_url) {
             if (request_url.length > 0) {
-                url.label = "<small><i>" + escape_url (request_url) + "</i></small>";
+                url.label = "<small><i>" + escape_url (variable_resolver.resolve_variables (request_url)) + "</i></small>";
             } else {
                 url.label = no_url;
             }

--- a/src/Widgets/meson.build
+++ b/src/Widgets/meson.build
@@ -22,6 +22,7 @@ sources += files(
     'Response/StatusBar/Container.vala',
     'Request/Container.vala',
     'Request/UrlEntry.vala',
+    'Request/Popover.vala',
     'Request/HeaderField.vala',
     'Request/BodyView.vala',
     'Request/Scripting/Container.vala',

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -101,6 +101,10 @@ namespace Spectator {
                 open_preferences ();
             });
 
+            this.headerbar.environments_clicked.connect (() => {
+                open_environments ();
+            });
+
             this.headerbar.new_collection.clicked.connect (() => {
                 this.create_collection_dialog ();
             });
@@ -108,6 +112,12 @@ namespace Spectator {
 
         private void open_preferences () {
             var dialog = new Dialogs.Preferences (this);
+
+            dialog.show_all ();
+        }
+
+        private void open_environments () {
+            var dialog = new Dialogs.Environments (this);
 
             dialog.show_all ();
         }

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -26,6 +26,7 @@ namespace Spectator {
         private Widgets.HeaderBar headerbar;
         private Widgets.Sidebar.Container sidebar;
         private Widgets.Content content;
+        public  Services.VariableResolver variable_resolver { get; private set; }
 
         private Repository.IRequest _request_service;
         public Repository.IRequest request_service {
@@ -87,6 +88,11 @@ namespace Spectator {
             this.collection_service = collection_service;
             this.order_service = order_service;
             this.environment_service = environment;
+            this.variable_resolver = new Services.VariableResolver (environment);
+            this.headerbar = new Widgets.HeaderBar ();
+            this.setup_headerbar_events ();
+            this.set_titlebar (this.headerbar);
+            this.create_paned ();
         }
 
         public void show_content () {
@@ -99,11 +105,6 @@ namespace Spectator {
             provider.load_from_resource ("/com/github/treagod/spectator/stylesheet.css");
             Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (),
                                                       provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
-
-            this.headerbar = new Widgets.HeaderBar ();
-            this.setup_headerbar_events ();
-            this.set_titlebar (this.headerbar);
-            this.create_paned ();
         }
 
         private void setup_headerbar_events () {

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -37,6 +37,16 @@ namespace Spectator {
             }
         }
 
+        private Repository.IEnvironment _environment_service;
+        public Repository.IEnvironment environment_service {
+            get {
+                return this._environment_service;
+            }
+            private set {
+                this._environment_service = value;
+            }
+        }
+
         private Repository.ICollection _collection_service;
         public Repository.ICollection collection_service {
             get {
@@ -57,8 +67,11 @@ namespace Spectator {
             }
         }
 
-        public Window (Gtk.Application app, Repository.IRequest request_service,
-                       Repository.ICollection collection_service, Repository.ICustomOrder order_service) {
+        public Window (Gtk.Application app,
+                       Repository.IRequest request_service,
+                       Repository.ICollection collection_service,
+                       Repository.ICustomOrder order_service,
+                       Repository.IEnvironment environment) {
             var settings = Settings.get_instance ();
             Object (application: app);
 
@@ -73,6 +86,7 @@ namespace Spectator {
             this.request_service = request_service;
             this.collection_service = collection_service;
             this.order_service = order_service;
+            this.environment_service = environment;
         }
 
         public void show_content () {

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -133,6 +133,11 @@ namespace Spectator {
 
         private void open_environments () {
             var dialog = new Dialogs.Environments (this);
+            
+
+            dialog.destroy.connect (() => {
+                this.sidebar.show_items ();
+            });
 
             dialog.show_all ();
         }

--- a/src/meson.build
+++ b/src/meson.build
@@ -5,7 +5,7 @@ conf_data.set('DATADIR', get_option('datadir'))
 conf_data.set('PKGDATADIR', get_option('datadir') + '/' + meson.project_name())
 conf_data.set('GETTEXT_PACKAGE', meson.project_name())
 conf_data.set('RELEASE_NAME', 'Spectator')
-conf_data.set('VERSION', '0.4.3')
+conf_data.set('VERSION', '0.6.0')
 conf_data.set('VERSION_INFO', 'Preview')
 conf_data.set('PREFIX', get_option('prefix'))
 

--- a/src/sql/init_sql.vala.in
+++ b/src/sql/init_sql.vala.in
@@ -27,4 +27,11 @@ namespace Spectator.Queries {
     namespace CustomOrder {
         public const string MOVE_REQUEST_AFTER_REQUEST = """@CUSTOM_ORDER_MOVE_REQUEST_AFTER_REQUEST@""";
     }
+
+    namespace Migrate060 {
+        public const string CREATE_ENVIRONMENT_TABLE = """@CREATE_ENVIRONMENT_TABLE@""";
+        public const string DROP_ENVIRONMENT_TABLE = """@DROP_ENVIRONMENT_TABLE@""";
+        public const string CREATE_VARIABLE_TABLE = """@CREATE_VARIABLE_TABLE@""";
+        public const string DROP_VARIABLE_TABLE = """@DROP_VARIABLE_TABLE@""";
+    }
 }

--- a/src/sql/meson.build
+++ b/src/sql/meson.build
@@ -5,6 +5,25 @@ sql_data.set('CUSTOM_ORDER_MOVE_REQUEST_AFTER_REQUEST', run_command(
     files('custom_order/move_request_after_request.sql'),
 ).stdout().strip())
 
+sql_data.set('CREATE_ENVIRONMENT_TABLE', run_command(
+    'cat',
+    files('migrate_0.6.0/create_environment_table.sql'),
+).stdout().strip())
+
+sql_data.set('CREATE_VARIABLE_TABLE', run_command(
+    'cat',
+    files('migrate_0.6.0/create_variable_table.sql'),
+).stdout().strip())
+
+sql_data.set('DROP_ENVIRONMENT_TABLE', run_command(
+    'cat',
+    files('migrate_0.6.0/drop_environment_table.sql'),
+).stdout().strip())
+
+sql_data.set('DROP_VARIABLE_TABLE', run_command(
+    'cat',
+    files('migrate_0.6.0/drop_environment_table.sql'),
+).stdout().strip())
 
 sql_init_header = configure_file(
     input: 'init_sql.vala.in',

--- a/src/sql/migrate_0.6.0/create_environment_table.sql
+++ b/src/sql/migrate_0.6.0/create_environment_table.sql
@@ -1,0 +1,5 @@
+CREATE TABLE if not exists Environment (
+	name TEXT NOT NULL,
+	created_at INTEGER NOT NULL,
+	CONSTRAINT Environment_PK PRIMARY KEY (name)
+);

--- a/src/sql/migrate_0.6.0/create_variable_table.sql
+++ b/src/sql/migrate_0.6.0/create_variable_table.sql
@@ -8,3 +8,17 @@ CREATE TABLE if not exists Variable (
     FOREIGN KEY(environment_name) REFERENCES Environment(name)
 	ON DELETE CASCADE
 );
+
+CREATE TRIGGER IF NOT EXISTS delete_variable_after_environment_deletion
+    AFTER DELETE ON Environment
+BEGIN
+    DELETE FROM Variable WHERE environment_name = OLD.name;
+END;
+
+CREATE TRIGGER IF NOT EXISTS update_variable_after_environment_deletion
+    AFTER UPDATE ON Environment
+BEGIN
+	UPDATE Variable
+	SET environment_name=NEW.name
+	WHERE Variable.environment_name=OLD.name;
+END;

--- a/src/sql/migrate_0.6.0/create_variable_table.sql
+++ b/src/sql/migrate_0.6.0/create_variable_table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE if not exists Variable (
+	id TEXT(36) NOT NULL,
+	"key" TEXT,
+	value TEXT,
+	created_at INTEGER,
+	environment_name TEXT,
+	CONSTRAINT Variable_PK PRIMARY KEY (id)
+    FOREIGN KEY(environment_name) REFERENCES Environment(name)
+	ON DELETE CASCADE
+);

--- a/src/sql/migrate_0.6.0/drop_environment_table.sql
+++ b/src/sql/migrate_0.6.0/drop_environment_table.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS Environment;

--- a/src/sql/migrate_0.6.0/drop_variable_table.sql
+++ b/src/sql/migrate_0.6.0/drop_variable_table.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS Variable;

--- a/src/sql/migrate_0.6.0/drop_variable_table.sql
+++ b/src/sql/migrate_0.6.0/drop_variable_table.sql
@@ -1,1 +1,3 @@
 DROP TABLE IF EXISTS Variable;
+DROP TRIGGER IF EXISTS delete_variable_after_environment_deletion;
+DROP TRIGGER IF EXISTS update_variable_after_environment_deletion;


### PR DESCRIPTION
These changes add environments and variables to Spectator.

A user can define environments and add variables to it. The defined variables can be used inside the URL entry (more supported inputs are coming).

To access the variables in the URL entry, the user has to press Ctrl+Space when then entry is focused.