### PR TITLE
Added flatpak manifest ready for elementary 6 AppCenter + actual style support

### DIFF
--- a/com.github.treagod.spectator.yml
+++ b/com.github.treagod.spectator.yml
@@ -1,0 +1,41 @@
+app-id: com.github.treagod.spectator
+runtime: io.elementary.Platform
+runtime-version: 'daily'
+sdk: io.elementary.Sdk
+command: com.github.treagod.spectator
+appstream-compose: false
+finish-args:
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=network
+  - --device=dri
+  # needed for perfers-color-scheme
+  - --system-talk-name=org.freedesktop.Accounts
+modules:
+
+  - name: gtksourceview
+    config-opts:
+      --disable-gtk-doc
+    sources:
+      - type: archive
+        url: https://download.gnome.org/sources/gtksourceview/3.24/gtksourceview-3.24.8.tar.xz
+        sha256: 1e9bb8ff190db705deb916dd23ff681f0e8803aec407bf0fd64c7e615ac436fe
+
+  - name: duktape
+    buildsystem: simple
+    build-commands:
+      - mv Makefile.sharedlibrary Makefile
+      - sed 's#INSTALL_PREFIX = /usr/local#INSTALL_PREFIX = /app#g' -i Makefile
+      - CFLAGS='$CFLAGS -D DUK_USE_FASTINT -w' INSTALL_PREFIX=/app make
+      - CFLAGS='$CFLAGS -D DUK_USE_FASTINT -w' INSTALL_PREFIX=/app make install
+
+    sources:
+      - type: archive
+        url: https://duktape.org/duktape-2.4.0.tar.xz
+        sha256: 86a89307d1633b5cedb2c6e56dc86e92679fc34b05be551722d8cc69ab0771fc
+
+  - name: spectator
+    buildsystem: meson
+    sources:
+      - type: dir
+        path: .


### PR DESCRIPTION
@treagod
It's really clean and doesn't pack a single unnecessary dependency. The app runs fine and communicates as intended with elementary OS to provide the user accent colour mode switching.
lime | pink
---------- | ----------
![grn](https://user-images.githubusercontent.com/58219504/117266452-2f0c9280-ae4d-11eb-8eee-430d6f170a27.png) | ![pnk](https://user-images.githubusercontent.com/58219504/117266493-392e9100-ae4d-11eb-92cf-63e51f6fb091.png)

I've also replaced the janky purely gtk dark style preference detection with the official granite.utils:
light | dark
---------- | ----------
![lgt](https://user-images.githubusercontent.com/58219504/117267950-b4447700-ae4e-11eb-9368-57d41f8c727d.png) | ![drk (1)](https://user-images.githubusercontent.com/58219504/117267994-bd354880-ae4e-11eb-8a99-e4f2a5c3a521.png)

I did what cassidy recommends; copy and pasting the vala example in Dippi

It might also be beneficial to bump gtksourceview to 4 since there aren't any breaking issues and it has the benefit of using meson (which plays well with everything else)

