### PR TITLE
.desktop: Add Postman to keywords

### DIFF
--- a/data/com.github.treagod.spectator.desktop.in
+++ b/data/com.github.treagod.spectator.desktop.in
@@ -8,4 +8,4 @@ Icon=com.github.treagod.spectator
 Terminal=false
 Type=Application
 X-GNOME-Gettext-Domain=spectator
-Keywords=REST;HTTP;Client;
+Keywords=REST;HTTP;Client;postman;


### PR DESCRIPTION
Since someone might be looking for an alternative to Postman, this seems fair.